### PR TITLE
fix: paths with URI encoded components

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -108,7 +108,7 @@ export function withParsedIpfsUrl (handler) {
       throw new HttpError(`unsupported protocol: ${pathParts[1]}`, { status: 400 })
     }
     dataCid = parseCid(pathParts[2])
-    const path = pathParts.slice(3).join('/')
+    const path = pathParts.slice(3).map(decodeURIComponent).join('/')
     const ipfsUrlCtx = { ...ctx, dataCid, path: path ? `/${path}` : '', searchParams }
     return handler(request, env, ipfsUrlCtx)
   }

--- a/test/middleware/parsed-ipfs-url.spec.js
+++ b/test/middleware/parsed-ipfs-url.spec.js
@@ -1,0 +1,25 @@
+/* eslint-env browser */
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { mockWaitUntil } from '../helpers.js'
+import { withParsedIpfsUrl } from '../../src/middleware.js'
+
+describe('withParsedIpfsUrl', () => {
+  it('should decode URI components in path', async () => {
+    const waitUntil = mockWaitUntil()
+    const ctx = { waitUntil }
+    const env = { DEBUG: 'true' }
+
+    const filename = 'Screenshot 2022-10-21 at 17.32.00.png'
+    const req = new Request(`http://localhost/ipfs/bafybeifwq2ywuoziunhtoecesw65p4exisfiskcklujke4fwrpx7y6b2ke/${encodeURIComponent(filename)}`, {
+      headers: { 'Cache-Control': 'only-if-cached' }
+    })
+
+    const res = await withParsedIpfsUrl((req, env, ctx) => {
+      assert.strictEqual(ctx.path, `/${filename}`)
+      return new Response()
+    })(req, env, ctx)
+
+    assert.strictEqual(res.status, 200)
+  })
+})

--- a/test/middleware/parsed-ipfs-url.spec.js
+++ b/test/middleware/parsed-ipfs-url.spec.js
@@ -11,9 +11,7 @@ describe('withParsedIpfsUrl', () => {
     const env = { DEBUG: 'true' }
 
     const filename = 'Screenshot 2022-10-21 at 17.32.00.png'
-    const req = new Request(`http://localhost/ipfs/bafybeifwq2ywuoziunhtoecesw65p4exisfiskcklujke4fwrpx7y6b2ke/${encodeURIComponent(filename)}`, {
-      headers: { 'Cache-Control': 'only-if-cached' }
-    })
+    const req = new Request(`http://localhost/ipfs/bafybeifwq2ywuoziunhtoecesw65p4exisfiskcklujke4fwrpx7y6b2ke/${encodeURIComponent(filename)}`)
 
     const res = await withParsedIpfsUrl((req, env, ctx) => {
       assert.strictEqual(ctx.path, `/${filename}`)


### PR DESCRIPTION
Previously this was causing freeway to return "file not found"