### PR TITLE
fix: better content-type detection for svg

### DIFF
--- a/src/util/mime.js
+++ b/src/util/mime.js
@@ -7,7 +7,20 @@ import { toString } from 'uint8arrays'
  * @param {string} fileName
  * @param {Uint8Array} bytes
  */
-export function detectContentType (fileName, bytes) {
+export function detectContentType (fileName = '', bytes) {
+  const mime = detectMagicBytes(fileName, bytes)
+  if (mime === 'application/xml') {
+    // xml could be svg or other specialised type, so dig deeper
+    return lookup(fileName) || detectTextContent(bytes, mime) || mime
+  }
+  return mime || lookup(fileName) || detectTextContent(bytes)
+}
+
+/**
+ * @param {string} fileName
+ * @param {Uint8Array} bytes
+ */
+function detectMagicBytes (fileName, bytes) {
   const infos = filetypeinfo(bytes)
   if (infos.length) {
     const idx = fileName.lastIndexOf('.')
@@ -16,22 +29,21 @@ export function detectContentType (fileName, bytes) {
     if (info?.mime) return info.mime
     if (infos[0].mime) return infos[0].mime
   }
-  return lookup(fileName) || detectTextContent(bytes)
 }
 
 /** @param {Uint8Array} bytes */
-function detectTextContent (bytes) {
+function detectTextContent (bytes, defaultMime = 'text/plain') {
   const encoding = chardet.detect(bytes)
   if (!encoding) return
-  let mime = 'text/plain'
+  let mime = defaultMime
   if (encoding === 'UTF-8' || encoding === 'ISO-8859-1') {
     const text = toString(bytes).toLowerCase()
     if (text.startsWith('<!doctype html')) {
       mime = 'text/html'
     } else if (text.includes('<svg')) {
       mime = 'image/svg+xml'
-    } else if (text.startsWith('<!xml')) {
-      mime = 'text/xml'
+    } else if (text.startsWith('<?xml')) {
+      mime = 'application/xml'
     }
   }
   return `${mime}; charset=${encoding}`

--- a/test/util/mime.spec.js
+++ b/test/util/mime.spec.js
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { detectContentType } from '../../src/util/mime.js'
+
+describe('mime', () => {
+  it('should return xml for a file with an xml declaration', () => {
+    // https://www.w3.org/TR/REC-xml/#sec-prolog-dtd
+    const str = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><root></root>'
+    const bytes = new TextEncoder().encode(str)
+    assert.equal(detectContentType('test.xml', bytes), 'application/xml')
+    assert.equal(detectContentType(undefined, bytes), 'application/xml; charset=ISO-8859-1')
+  })
+
+  it('should return svg for an svg file with xml declaration', () => {
+    // https://www.w3.org/TR/SVG2/struct.html#NewDocument
+    const str = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg></svg>'
+    const bytes = new TextEncoder().encode(str)
+    assert.equal(detectContentType('test.svg', bytes), 'image/svg+xml')
+    assert.equal(detectContentType(undefined, bytes), 'image/svg+xml; charset=ISO-8859-1')
+  })
+
+  it('should return svg for a file with an svg element as root', () => {
+    // https://www.w3.org/TR/SVG2/struct.html#NewDocument
+    const str = '<svg></svg>'
+    const bytes = new TextEncoder().encode(str)
+    assert.equal(detectContentType('test.svg', bytes), 'image/svg+xml')
+    // Note: chardet uses byte occurance statistics to guess char encoding. This short string tips in favour of UTF-8.
+    // see: https://github.com/runk/node-chardet/blob/master/src/index.ts#L52-L53
+    assert.equal(detectContentType(undefined, bytes), 'image/svg+xml; charset=UTF-8')
+  })
+
+  it('should return html for an html file', () => {
+    // https://html.spec.whatwg.org/multipage/syntax.html#the-doctype
+    const str = '<!DOCTYPE html><svg></svg>'
+    const bytes = new TextEncoder().encode(str)
+    assert.equal(detectContentType('test.html', bytes), 'text/html')
+    assert.equal(detectContentType(undefined, bytes), 'text/html; charset=ISO-8859-1')
+  })
+})


### PR DESCRIPTION
Catch svgs and other specialised xml flavours by running our extention check and text content checks when the magic bytes check determines the file is `application/xml`

- adds tests
- fixes our content check to look for an xml declaration that starts with `<?xml` rather than `<!xml`, per https://www.w3.org/TR/REC-xml/#sec-prolog-dtd

Note that chardet uses byte counting statistics to guess the character encoding of a file; one of our tests lands in favour of `UTF-8` rather than `ISO-8859-1`, but it's ok.

see: https://github.com/runk/node-chardet/blob/master/src/index.ts#L52-L53

fixes: https://github.com/web3-storage/freeway/issues/19

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>