### PR TITLE
fix: allow hash in filenames

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,5 +13,7 @@ runs:
       shell: bash
     - run: npm run lint
       shell: bash
+    - run: npm run build
+      shell: bash
     - run: npm test
       shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@web3-storage/gateway-lib",
   "version": "2.0.2",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -13,7 +13,7 @@
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^1.5.0",
-        "dagula": "^4.2.0",
+        "dagula": "^5.0.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
         "multiformats": "^11.0.1",
@@ -127,16 +127,40 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
+      "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "espree": "^9.5.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -172,16 +196,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/@eslint/js": {
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
       "engines": {
-        "node": "*"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@handlebars/parser": {
@@ -190,29 +211,17 @@
       "integrity": "sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A=="
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -288,9 +297,9 @@
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.12.tgz",
-      "integrity": "sha512-IvTKqI+7O9sTd7K9JSIRsOj/oruKj66qSopbSWkUd6KkcrYvm5vnreb39XPP+nitZcZFQyXj/ZDqTidAWWfYAg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.14.tgz",
+      "integrity": "sha512-kS9bsRPS6qrbGiMfICjVUTjva7Bq0kCE0DTVGgFixH8e2RtF/7K8bWzO52aTQVPUF7vpId7cmmYAaHde1ZYh0A==",
       "dependencies": {
         "@libp2p/interface-keys": "^1.0.2",
         "@libp2p/interfaces": "^3.2.0",
@@ -298,12 +307,29 @@
         "@noble/secp256k1": "^1.5.4",
         "multiformats": "^11.0.0",
         "node-forge": "^1.1.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
         "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/protons-runtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/@libp2p/interface-address-manager": {
@@ -320,9 +346,9 @@
       }
     },
     "node_modules/@libp2p/interface-connection": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
-      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.1.0.tgz",
+      "integrity": "sha512-UfluPclTyJp5nBVKQVJ7Xrwp45fFYeIPuyfCpZfTKOfT/srSntA5l+094H6f1bGSj6SbwZ4V7BxCxviJQM5PBg==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -365,9 +391,9 @@
       }
     },
     "node_modules/@libp2p/interface-content-routing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.1.tgz",
-      "integrity": "sha512-M3rYXMhH+102qyZzc0GzkKq10x100nWVXGns2qtN3O82Hy/6FxXdgLUGIGWMdCj/7ilaVAuTwx8V3+DGmDIiMw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.2.tgz",
+      "integrity": "sha512-SlyZnBk+IpTKdT/4RMNTHcl18PRWUXfb3qhkBPP8xBNGm57DxApKQjLjoklSRNwJ3VDmXyPqTpiR/K/pLPow6A==",
       "dependencies": {
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -491,9 +517,9 @@
       }
     },
     "node_modules/@libp2p/interface-peer-routing": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.7.tgz",
-      "integrity": "sha512-0zxOOmKD6nA3LaArcP9UdRO4vJzEyoRtE34vvQP41UxjcSTaj4em5Fl4Q0RuOMXYPtRp+LdXRYbjJgCSeQoxwA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.8.tgz",
+      "integrity": "sha512-ArJWymWvHqVNyHSZ+7T9av2A4r0f1zTPMKe3+7BOX3n2mB8hP2nNMz/Kiun41TH0t80zMiXE73ZD29is27yt9g==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
@@ -550,9 +576,9 @@
       }
     },
     "node_modules/@libp2p/interface-registrar": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.8.tgz",
-      "integrity": "sha512-WbnXB09QF41zZzNgDUAZrRMilqgB7wBMTsSvql8xdDcws+jbaX4wE0iEpRXg1hyd0pz4mooIcMRaH1NiEQ5D8w==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.9.tgz",
+      "integrity": "sha512-+aZg7SB8fIddE4/PojnHY2Y29vwr4YtnXxro3db/TYWAsWNGlgZusFEZYqBMpV/1KpEFBdi3O7r50bv/2fRusQ==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.0",
         "@libp2p/interface-peer-id": "^2.0.0"
@@ -602,13 +628,13 @@
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
-      "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
+      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
-        "interface-datastore": "^7.0.0",
+        "interface-datastore": "^8.0.0",
         "multiformats": "^11.0.0"
       },
       "engines": {
@@ -696,16 +722,16 @@
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.1.tgz",
-      "integrity": "sha512-CRJmqwNQhDC51sQ9lf6EqEY8HuywwymMVffL2kIYI5ts5k+6gvIXzoSxLf3V3o+OxcroXG4KG0uGxxAi5DUXSA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.2.tgz",
+      "integrity": "sha512-cnny4gkZf1HQ7aZVeZii3xY4DBSPW+O29GvnhECRF55SkRa5xzkZMVnoKX2d+9wBbS4t3ng2kOF2HtgSIySfWw==",
       "dependencies": {
         "@libp2p/crypto": "^1.0.0",
         "@libp2p/interface-keys": "^1.0.2",
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/peer-id": "^2.0.0",
         "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^4.0.2"
       },
@@ -714,67 +740,127 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-record": {
+    "node_modules/@libp2p/peer-id-factory/node_modules/protons-runtime": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.0.tgz",
-      "integrity": "sha512-qGaqYQSRqI/vol1NEMR9Z3ncLjIkyIF0o/CQYXzXCDjA91i9+0iMjXGgIgBLn3bfA1b9pHuz4HvwjgYUKMYOkQ==",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
+      }
+    },
+    "node_modules/@libp2p/peer-record": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.2.tgz",
+      "integrity": "sha512-Cqaj3pC9zQHKE1FYE7B1OcMVWQkQNjLaSH2ioavz3PMPWGy+5m4dVK9hvSyoEf8PfRKFT+x92MONbappEFBwvg==",
       "dependencies": {
         "@libp2p/crypto": "^1.0.11",
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-record": "^2.0.1",
-        "@libp2p/logger": "^2.0.5",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/peer-id": "^2.0.0",
         "@libp2p/utils": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^7.0.0",
-        "it-all": "^2.0.0",
-        "it-filter": "^2.0.0",
-        "it-foreach": "^1.0.0",
-        "it-map": "^2.0.0",
-        "it-pipe": "^2.0.3",
-        "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
         "uint8-varint": "^1.0.2",
         "uint8arraylist": "^2.1.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
+      }
+    },
     "node_modules/@libp2p/peer-store": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.0.tgz",
-      "integrity": "sha512-7GSqRYkJR3E0Vo96XH84X6KNPdwOE1t6jb7jegYzvzKDZMFaceJUZg9om3+ZHCUbethnYuqsY7j0c7OHCB40nA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.4.tgz",
+      "integrity": "sha512-yw7XbeJ5k880PpkDV/HcSZtj0vQ0ShPbnCzVHc1hW0JS/g1vhpSooAZOf3w65obUoFhUwccnSZ4HSLBSpQqOaA==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.3",
         "@libp2p/interface-peer-store": "^1.2.2",
         "@libp2p/interface-record": "^2.0.1",
-        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/peer-id": "^2.0.0",
         "@libp2p/peer-record": "^5.0.0",
         "@multiformats/multiaddr": "^11.0.0",
-        "err-code": "^3.0.1",
         "interface-datastore": "^7.0.0",
         "it-all": "^2.0.0",
         "it-filter": "^2.0.0",
         "it-foreach": "^1.0.0",
         "it-map": "^2.0.0",
-        "it-pipe": "^2.0.3",
         "mortice": "^3.0.0",
         "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.1.1",
         "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/protons-runtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/@libp2p/tcp": {
@@ -832,9 +918,9 @@
       }
     },
     "node_modules/@libp2p/websockets": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.3.tgz",
-      "integrity": "sha512-/0ie47LEKU5VVeaeE/T6UbvaZbUSmyWXu4KcojY+zl809oONFjagKuZB6T7jJQqAV7WCq7O+ulC2tFOwbID08w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.5.tgz",
+      "integrity": "sha512-gp6OI/2cBBkbUKw7XougNC8/XZe1fe5eSngWDSE99/wGykwDzyKPnYikUAGhJ4X1VuBDAjogZuJp7PtDif1QPQ==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.2",
         "@libp2p/interface-transport": "^2.0.0",
@@ -848,7 +934,8 @@
         "it-ws": "^5.0.6",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1"
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -856,9 +943,9 @@
       }
     },
     "node_modules/@multiformats/mafmt": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
-      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.1.0.tgz",
+      "integrity": "sha512-ZGuP26SIbBZutDN/QhqGwuu7b1zTO9DLvG4l3fh15ambPmcwS811MQIyW+d+9Vl7ASheB0qJq0sJrMKsHS3dXA==",
       "dependencies": {
         "@multiformats/multiaddr": "^11.0.0"
       },
@@ -868,9 +955,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
-      "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -897,18 +984,17 @@
       }
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
-      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
+      "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
       "dependencies": {
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
-    },
-    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
@@ -1159,115 +1245,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "node_modules/@types/node": {
-      "version": "18.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.4.tgz",
-      "integrity": "sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow=="
+      "version": "18.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.1.tgz",
-      "integrity": "sha512-ylJN3q6/H2IiDaFLXdDSnSx02dFaa7EqSZGCKN20TlSk0ZvBbQ9BXs1q/arik64KZ/OqtLMwBivehMs+dUO7Gg==",
-      "dependencies": {
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-pb": "^2.0.2",
-        "@multiformats/murmur3": "^1.0.3",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "interface-blockstore": "^2.0.3",
-        "ipfs-unixfs": "^6.0.0",
-        "it-last": "^1.0.5",
-        "multiformats": "^9.4.2",
-        "p-queue": "^7.3.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/@ipld/dag-cbor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
-      "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/@ipld/dag-pb": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
-      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
-      "dependencies": {
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/ipfs-unixfs": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
-      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
-    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
     },
     "node_modules/@web3-storage/handlebars": {
       "version": "1.0.0",
@@ -1299,9 +1285,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1388,16 +1374,29 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -1407,24 +1406,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -1435,14 +1425,14 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -1452,6 +1442,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "node_modules/atomically": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
@@ -1459,6 +1462,18 @@
       "dependencies": {
         "stubborn-fs": "^1.2.4",
         "when-exit": "^2.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1484,18 +1499,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/builtins": {
@@ -1584,22 +1587,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-      "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.1.tgz",
+      "integrity": "sha512-0XMOtA52igKDOIfvJZJ6v0+J9yMF3IuYyEa5oFUxBXA01G6mwCNKpul3bgbFf7lmZuqwN/oyg/zQ1cGS7NyJkQ=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -1668,9 +1659,9 @@
       }
     },
     "node_modules/dagula": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.2.0.tgz",
-      "integrity": "sha512-X0vzLcAmbpuBH0Xb4Bp47L8idLQFYKuY78mgv2P0WeeZX3pQ2drioku4X0GcxntQUsK/AO/0uXo0kZ+9KBjkrQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-5.0.0.tgz",
+      "integrity": "sha512-cGlHQuIiNNyxP/ehMFuKCw59FMn+1zC+ESGmMuHc552bIIxLChfNwghY0bRGe0JyyS2pCi/5E+QcDTEfpxcxbw==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^11.0.0",
         "@ipld/car": "^5.0.3",
@@ -1685,10 +1676,10 @@
         "@libp2p/tcp": "^6.0.9",
         "@libp2p/websockets": "^5.0.3",
         "@multiformats/multiaddr": "^11.3.0",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.1",
         "archy": "^1.0.0",
         "conf": "^11.0.1",
         "debug": "^4.3.4",
+        "ipfs-unixfs-exporter": "^12.0.2",
         "it-length-prefixed": "^8.0.4",
         "it-pipe": "^2.0.3",
         "libp2p": "^0.42.2",
@@ -1721,6 +1712,29 @@
         "it-take": "^2.0.0",
         "uint8arrays": "^4.0.2"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1774,9 +1788,9 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -1787,18 +1801,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dns-over-http-resolver": {
@@ -1842,17 +1844,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/dot-prop/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1884,41 +1875,65 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
+        "string.prototype.trim": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
@@ -1968,14 +1983,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
+        "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1983,22 +2002,21 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "espree": "^9.5.0",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
-        "globby": "^11.1.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -2007,7 +2025,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -2073,13 +2090,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -2161,23 +2179,25 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
         "tsconfig-paths": "^3.14.1"
       },
       "engines": {
@@ -2188,12 +2208,12 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
@@ -2208,38 +2228,29 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
     "node_modules/eslint-plugin-n": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.3.0.tgz",
-      "integrity": "sha512-IyzPnEWHypCWasDpxeJnim60jhlumbmq0pubL6IOcnk8u2y53s5QfT8JnXy7skjHJ44yWHRb11PLtDHuu1kg/Q==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.1.tgz",
+      "integrity": "sha512-R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==",
       "dev": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.10.0",
+        "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.1",
-        "semver": "^7.3.7"
+        "semver": "^7.3.8"
       },
       "engines": {
         "node": ">=12.22.0"
@@ -2251,22 +2262,10 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/eslint-plugin-promise": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.1.tgz",
-      "integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2276,25 +2275,26 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.31.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
-      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
+      "version": "7.32.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.8"
       },
       "engines": {
         "node": ">=4"
@@ -2313,18 +2313,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -2418,122 +2406,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "node_modules/eslint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/eslint/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/espree": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -2548,9 +2430,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -2639,22 +2521,6 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
       "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
     },
-    "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2668,9 +2534,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2688,28 +2554,20 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat-cache": {
@@ -2730,6 +2588,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
     },
     "node_modules/freeport-promise": {
       "version": "2.0.0",
@@ -2788,9 +2655,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -2846,15 +2713,15 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -2866,33 +2733,21 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2904,24 +2759,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -2937,29 +2811,16 @@
       "dev": true
     },
     "node_modules/hamt-sharding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
-      "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
       "dependencies": {
         "sparse-array": "^1.3.1",
-        "uint8arrays": "^3.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/hamt-sharding/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
-    "node_modules/hamt-sharding/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/has": {
@@ -2999,6 +2860,18 @@
       "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3045,9 +2918,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -3095,34 +2968,19 @@
       "dev": true
     },
     "node_modules/interface-blockstore": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
-      "integrity": "sha512-OwVUnlNcx7H5HloK0Myv6c/C1q9cNG11HX6afdeU6q6kbuNj8jKCwVnmJHhC94LZaJ+9hvVOk4IUstb3Esg81w==",
-      "dependencies": {
-        "interface-store": "^2.0.2",
-        "multiformats": "^9.0.4"
-      }
-    },
-    "node_modules/interface-blockstore/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
-    "node_modules/interface-datastore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
-      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+      "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
       "dependencies": {
         "interface-store": "^3.0.0",
-        "nanoid": "^4.0.0",
-        "uint8arrays": "^4.0.2"
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/interface-datastore/node_modules/interface-store": {
+    "node_modules/interface-blockstore/node_modules/interface-store": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
       "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
@@ -3131,18 +2989,36 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/interface-datastore": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.0.0.tgz",
+      "integrity": "sha512-RRkUskUnBn4q6pGCMgc3j4t+MxVgj6SNADQPna63/MOvYk36yxj3sJh/8Apj8MLAMtzCosXhbCi82S/9W1z3qg==",
+      "dependencies": {
+        "interface-store": "^4.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/interface-store": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-4.0.0.tgz",
+      "integrity": "sha512-cApTZjtMixGyIVNKw6cFcPJTL0KLEbUslhn7hzaKRonQqjjQxzEnklGZkreqmgbVlwOPLQ06s0Qg6F1yOYzfow==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -3173,7 +3049,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
       "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
-      "dev": true,
       "dependencies": {
         "err-code": "^3.0.1",
         "protons-runtime": "^5.0.0",
@@ -3184,11 +3059,37 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-unixfs-exporter": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-12.0.2.tgz",
+      "integrity": "sha512-bt93YHQplKWFPqZCsAZLBbHG11dNuJtyvnZakcKmbYUC8iPyy0dfHPcTEB8Rz6JL7lSAJp7M4g4dCdv2U6sBGw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^4.0.1",
+        "ipfs-unixfs": "^11.0.0",
+        "it-filter": "^2.0.0",
+        "it-last": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^11.0.0",
+        "p-queue": "^7.3.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/ipfs-unixfs/node_modules/protons-runtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
       "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
-      "dev": true,
       "dependencies": {
         "protobufjs": "^7.0.0",
         "uint8arraylist": "^2.4.3"
@@ -3199,6 +3100,20 @@
       },
       "peerDependencies": {
         "uint8arraylist": "^2.3.2"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -3248,9 +3163,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -3325,15 +3240,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-number-object": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
@@ -3347,6 +3253,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3426,6 +3341,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -3452,18 +3386,18 @@
       }
     },
     "node_modules/it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-batched-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.0.tgz",
-      "integrity": "sha512-OfztV9UHQmoZ6u5F4y+YOI1Z+5JAhkv3Gexc1a0B7ikcVXc3PFSKlEnHv79u+Yp/h23o3tsF9hHAhuqgHCYT2Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.1.tgz",
+      "integrity": "sha512-ptBiZ0Mh3kJYySpG0pCS7JgvWhaAW1fGfKDVFtNIuNTA+bpSlXINvD5H3b14ZlJbnJFzFzRSCSZ10E1nH4z/WQ==",
       "dependencies": {
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
@@ -3475,36 +3409,36 @@
       }
     },
     "node_modules/it-drain": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.0.tgz",
-      "integrity": "sha512-oa/5iyBtRs9UW486vPpyDTC0ee3rqx5qlrPI7txIUJcqqtiO5yVozEB6LQrl5ysQYv+P3y/dlKEqwVqlCV0SEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+      "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
-      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+      "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-first": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
-      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-foreach": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.0.tgz",
-      "integrity": "sha512-2j5HK1P6aMwEvgL6K5nzUwOk+81B/mjt05PxiSspFEKwJnqy1LfJYlLLS6llBoM+NdoUxf6EsBCHidFGmsXvhw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.1.tgz",
+      "integrity": "sha512-eaVFhKxU+uwPs7+DKYxjuL6pj6c50/MBlAH+XPMgPWRRVIChVoyEIsdUQkkC0Ad6oTUmJbKRTnJxEY6o2aIs7A==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3527,9 +3461,13 @@
       }
     },
     "node_modules/it-last": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
-      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
+      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-length-prefixed": {
       "version": "8.0.4",
@@ -3548,18 +3486,18 @@
       }
     },
     "node_modules/it-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
-      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-merge": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
-      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
       "dependencies": {
         "it-pushable": "^3.1.0"
       },
@@ -3574,6 +3512,18 @@
       "integrity": "sha512-S3y3mTJ3muuxcHBGcIzNONofAN+G3iAgmSjS78qARkRWI2ImJXybjj0h52uSW+isgrJqIx2iFB/T8ZEBc8kDSw==",
       "dependencies": {
         "it-stream-types": "^1.0.3",
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.1.tgz",
+      "integrity": "sha512-Wq9DcoLrFV9n5YzWC4BlOQT+v5qgir/iIO/CJ1eV0T5t9rcCZFPKOZB3E8wIhZ5ruSApc2w7UKrbn5iENqew5A==",
+      "dependencies": {
         "p-defer": "^4.0.0"
       },
       "engines": {
@@ -3633,9 +3583,9 @@
       }
     },
     "node_modules/it-sort": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.0.tgz",
-      "integrity": "sha512-yeAE97b5PEjCrWFUiNyR90eJdGslj8FB3cjT84rsc+mzx9lxPyR2zJkYB9ZOJoWE5MMebxqcQCLRT3OSlzo7Zg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.1.tgz",
+      "integrity": "sha512-9f4jKOTHfxc/FJpg/wwuQ+j+88i+sfNGKsu2HukAKymm71/XDnBFtOAOzaimko3YIhmn/ERwnfEKrsYLykxw9A==",
       "dependencies": {
         "it-all": "^2.0.0"
       },
@@ -3654,9 +3604,9 @@
       }
     },
     "node_modules/it-take": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.0.tgz",
-      "integrity": "sha512-lN3diSTomOvYBk2K0LHAgrQ52DlQfvq8tH/+HLAFpX8Q3JwBkr/BPJEi3Z3Lf8jMmN1KOCBXvt5sXa3eW9vUmg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.1.tgz",
+      "integrity": "sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3679,10 +3629,14 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-      "dev": true
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3730,9 +3684,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -3846,6 +3800,29 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/libp2p/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
@@ -3872,16 +3849,18 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
@@ -3896,9 +3875,9 @@
       "dev": true
     },
     "node_modules/long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/longbits": {
       "version": "1.1.0",
@@ -3937,9 +3916,9 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.12.tgz",
-      "integrity": "sha512-Rkukya32FnY3dF5nJeAS4Qcry76tXeOe2sXIQGAt969sV04QLormWHXmHn4o/yIbb4wRlnCqWu8fpVg3TU7sFg=="
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.14.tgz",
+      "integrity": "sha512-Xz644ideT892A7l9JtYLlVp3KjQc8gHJP9rN6H2Mq8OOld6BMU7xiS9rFGYAXeY7Z/yHOYtFSLyFzL8/NaodPw=="
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -3957,28 +3936,6 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -3990,10 +3947,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4036,9 +4005,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiformats": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
-      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -4119,9 +4088,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4155,28 +4124,28 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
-      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4186,27 +4155,27 @@
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
-      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
       "dev": true,
       "dependencies": {
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4315,27 +4284,42 @@
       }
     },
     "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "dependencies": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4454,12 +4438,12 @@
       }
     },
     "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4485,27 +4469,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4526,6 +4489,67 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/platform": {
@@ -4568,9 +4592,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -4607,9 +4631,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -4880,15 +4904,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5015,47 +5030,64 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5106,6 +5138,18 @@
       "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
       "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -5132,18 +5176,6 @@
         "retimer": "^3.0.0"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -5153,13 +5185,13 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
@@ -5177,21 +5209,34 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5202,9 +5247,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -5268,9 +5313,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -5351,6 +5396,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -5383,9 +5448,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5467,9 +5532,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
       }
@@ -5484,4045 +5549,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    }
-  },
-  "dependencies": {
-    "@achingbrain/ip-address": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@achingbrain/ip-address/-/ip-address-8.1.0.tgz",
-      "integrity": "sha512-Zus4vMKVRDm+R1o0QJNhD0PD/8qRGO3Zx8YPsFG5lANt5utVtGg3iHVGBSAF80TfQmhi8rP+Kg/OigdxY0BXHw==",
-      "requires": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "1.1.2"
-      }
-    },
-    "@achingbrain/nat-port-mapper": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.7.tgz",
-      "integrity": "sha512-P8Z8iMZBQCsN7q3XoVoJAX3CGPUTbGTh1XBU8JytCW3hBmSk594l8YvdrtY5NVexVHSwLeiXnDsP4d10NJHaeg==",
-      "requires": {
-        "@achingbrain/ssdp": "^4.0.1",
-        "@libp2p/logger": "^2.0.0",
-        "default-gateway": "^6.0.2",
-        "err-code": "^3.0.1",
-        "it-first": "^1.0.7",
-        "p-defer": "^4.0.0",
-        "p-timeout": "^5.0.2",
-        "xml2js": "^0.4.23"
-      },
-      "dependencies": {
-        "it-first": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-          "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
-        },
-        "p-timeout": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
-        }
-      }
-    },
-    "@achingbrain/ssdp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.1.tgz",
-      "integrity": "sha512-z/CkfFI0Ksrpo8E+lu2rKahlE1KJHUn8X8ihQj2Jg6CEL+oHYGCNfttOES0+VnV7htuog70c8bYNHYhlmmqxBQ==",
-      "requires": {
-        "event-iterator": "^2.0.0",
-        "freeport-promise": "^2.0.0",
-        "merge-options": "^3.0.4",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23"
-      }
-    },
-    "@chainsafe/is-ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
-      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
-    },
-    "@chainsafe/libp2p-noise": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.1.tgz",
-      "integrity": "sha512-pByMPsbuuiAherDV7DRB/sBmxWJcLt2tkuST4vFpv6FZb3/AxKp+ck2f4pHFNaUCaFbGLQa2wN903i8tq8Qr7Q==",
-      "requires": {
-        "@libp2p/crypto": "^1.0.11",
-        "@libp2p/interface-connection-encrypter": "^3.0.5",
-        "@libp2p/interface-keys": "^1.0.6",
-        "@libp2p/interface-metrics": "^4.0.4",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/logger": "^2.0.5",
-        "@libp2p/peer-id": "^2.0.0",
-        "@stablelib/chacha20poly1305": "^1.0.1",
-        "@stablelib/hkdf": "^1.0.1",
-        "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.3",
-        "it-length-prefixed": "^8.0.2",
-        "it-pair": "^2.0.2",
-        "it-pb-stream": "^2.0.2",
-        "it-pipe": "^2.0.3",
-        "it-stream-types": "^1.0.4",
-        "protons-runtime": "^4.0.1",
-        "uint8arraylist": "^2.3.2",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.4.0",
-        "globals": "^13.15.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "@handlebars/parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-1.1.0.tgz",
-      "integrity": "sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A=="
-    },
-    "@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
-      "dev": true,
-      "requires": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true
-    },
-    "@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
-    },
-    "@ipld/car": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
-      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
-      "requires": {
-        "@ipld/dag-cbor": "^9.0.0",
-        "cborg": "^1.9.0",
-        "multiformats": "^11.0.0",
-        "varint": "^6.0.0"
-      }
-    },
-    "@ipld/dag-cbor": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
-      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
-      "requires": {
-        "cborg": "^1.10.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@ipld/dag-json": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
-      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
-      "requires": {
-        "cborg": "^1.10.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@ipld/dag-pb": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
-      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
-      "requires": {
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@libp2p/crypto": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.12.tgz",
-      "integrity": "sha512-IvTKqI+7O9sTd7K9JSIRsOj/oruKj66qSopbSWkUd6KkcrYvm5vnreb39XPP+nitZcZFQyXj/ZDqTidAWWfYAg==",
-      "requires": {
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interfaces": "^3.2.0",
-        "@noble/ed25519": "^1.6.0",
-        "@noble/secp256k1": "^1.5.4",
-        "multiformats": "^11.0.0",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^4.0.1",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "@libp2p/interface-address-manager": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.4.tgz",
-      "integrity": "sha512-RcSi+z+xpVKJXq3BsfLf2rq8zb8VTAFown6uJBu02towMc0enYqqhwlV9DxcCaC573MgQ7gY2s/3XvxQdFraVA==",
-      "requires": {
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-connection": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
-      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.2"
-      }
-    },
-    "@libp2p/interface-connection-encrypter": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
-      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.2"
-      }
-    },
-    "@libp2p/interface-connection-manager": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.7.tgz",
-      "integrity": "sha512-GyRa7FXtwjbch4ucFa/jj6vcaQT2RyhUbH3q0tIOTzjntABTMzQrhn3BWOGU5deRp2K7cVOB/OzrdhHdGUxYQA==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-content-routing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.1.tgz",
-      "integrity": "sha512-M3rYXMhH+102qyZzc0GzkKq10x100nWVXGns2qtN3O82Hy/6FxXdgLUGIGWMdCj/7ilaVAuTwx8V3+DGmDIiMw==",
-      "requires": {
-        "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-dht": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.1.tgz",
-      "integrity": "sha512-+yEbt+1hMTR1bITzYyE771jEujimPXqDyFm8T1a8slMpeOD9z5wmLfuCWif8oGZJzXX5YqldWwSwytJQgWXL9g==",
-      "requires": {
-        "@libp2p/interface-peer-discovery": "^1.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-keychain": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
-      "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-keys": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
-      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA=="
-    },
-    "@libp2p/interface-libp2p": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.1.1.tgz",
-      "integrity": "sha512-cELZZv/tzFxbUzL3Jvbk+AM2J6kDhIUNBIMMMLuR3LIHfmVJkh31G3ChLUZuKhBwB8wXJ1Ssev3fk1tfz/5DWA==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-content-routing": "^2.0.0",
-        "@libp2p/interface-dht": "^2.0.0",
-        "@libp2p/interface-keychain": "^2.0.0",
-        "@libp2p/interface-metrics": "^4.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interface-peer-routing": "^1.0.0",
-        "@libp2p/interface-peer-store": "^1.0.0",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@libp2p/interface-registrar": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-metrics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0"
-      }
-    },
-    "@libp2p/interface-peer-discovery": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-1.0.5.tgz",
-      "integrity": "sha512-R0TN/vDaCJLvRhop0y4qoPqapHxX4AEQDEtqmpayAA1BuPgbBq4fS4mepR3FAMcNva/szeqVCDuI4gDejtCaVg==",
-      "requires": {
-        "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interfaces": "^3.0.0"
-      }
-    },
-    "@libp2p/interface-peer-id": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
-      "requires": {
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-peer-info": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
-      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-peer-routing": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.7.tgz",
-      "integrity": "sha512-0zxOOmKD6nA3LaArcP9UdRO4vJzEyoRtE34vvQP41UxjcSTaj4em5Fl4Q0RuOMXYPtRp+LdXRYbjJgCSeQoxwA==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interfaces": "^3.0.0"
-      }
-    },
-    "@libp2p/interface-peer-store": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.8.tgz",
-      "integrity": "sha512-FM9VLmpg9CUBKZ2RW+J7RrQfQVMksLiC8oqENqHgb/VkPJY3kafbn7HIi0NcK6H/H5VcwBIhL15SUJk66O1K6g==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interface-record": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@libp2p/interface-pubsub": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
-      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "it-pushable": "^3.0.0",
-        "uint8arraylist": "^2.1.2"
-      }
-    },
-    "@libp2p/interface-record": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.6.tgz",
-      "integrity": "sha512-4EtDkY3sbYapWM8++gVHlv31HZXoLmj9I7CRXUKXzFkVE0GLK/A8jYWl7K0lmf2juPjeYm2eHITeA9/wAtIS3w==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "uint8arraylist": "^2.1.2"
-      }
-    },
-    "@libp2p/interface-registrar": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.8.tgz",
-      "integrity": "sha512-WbnXB09QF41zZzNgDUAZrRMilqgB7wBMTsSvql8xdDcws+jbaX4wE0iEpRXg1hyd0pz4mooIcMRaH1NiEQ5D8w==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-peer-id": "^2.0.0"
-      }
-    },
-    "@libp2p/interface-stream-muxer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
-      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "it-stream-types": "^1.0.4"
-      }
-    },
-    "@libp2p/interface-transport": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.1.tgz",
-      "integrity": "sha512-xDM/s8iPN/XfNqD9qNelibRMPKkhOLinXwQeNtoTZjarq+Cg6rtO6/5WBG/49hyI3+r+5jd2eykjPGQbb86NFQ==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "it-stream-types": "^1.0.4"
-      }
-    },
-    "@libp2p/interfaces": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
-    },
-    "@libp2p/logger": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
-      "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^7.0.0",
-        "multiformats": "^11.0.0"
-      }
-    },
-    "@libp2p/mplex": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.1.tgz",
-      "integrity": "sha512-0owK1aWgXXtjiohXtjwLV7Ehjdj96eBtsapVt7AzlHA+W8uYnI+x058thq3MisyMDlHiiE3BTh6fEf+t2/0dUw==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.1",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/logger": "^2.0.0",
-        "abortable-iterator": "^4.0.2",
-        "any-signal": "^3.0.0",
-        "benchmark": "^2.1.4",
-        "err-code": "^3.0.1",
-        "it-batched-bytes": "^1.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.4",
-        "rate-limiter-flexible": "^2.3.9",
-        "uint8arraylist": "^2.1.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      }
-    },
-    "@libp2p/multistream-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.2.tgz",
-      "integrity": "sha512-NfF0fwQM4sqiLuNGBVc9z2mfz3OigOfyLJ5zekRBGYHkbKWrBRFS3FligUPr9roCOzH6ojjDkKVd5aK9/llfJQ==",
-      "requires": {
-        "@libp2p/interfaces": "^3.0.2",
-        "@libp2p/logger": "^2.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "it-first": "^2.0.0",
-        "it-handshake": "^4.1.2",
-        "it-length-prefixed": "^8.0.3",
-        "it-merge": "^2.0.0",
-        "it-pipe": "^2.0.4",
-        "it-pushable": "^3.1.0",
-        "it-reader": "^6.0.1",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0",
-        "uint8arraylist": "^2.3.1",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "@libp2p/peer-collections": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.0.tgz",
-      "integrity": "sha512-rVhfDmkVzfBVR4scAfaKb05htZENx01PYt2USi1EnODyoo2c2U2W5tfOfyaKI/4D+ayQDOjT27G0ZCyAgwkYGw==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/peer-id": "^2.0.0"
-      }
-    },
-    "@libp2p/peer-id": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.2.tgz",
-      "integrity": "sha512-RBjCMtSLnX43OK6zIpMW/cKzEgnsunihgyVPhnB/U7DAAEnovxe8F1Q4jBQp9+9DYSgQJrsdiEBpT5JH0Eh2lA==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "@libp2p/peer-id-factory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.1.tgz",
-      "integrity": "sha512-CRJmqwNQhDC51sQ9lf6EqEY8HuywwymMVffL2kIYI5ts5k+6gvIXzoSxLf3V3o+OxcroXG4KG0uGxxAi5DUXSA==",
-      "requires": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "@libp2p/peer-record": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.0.tgz",
-      "integrity": "sha512-qGaqYQSRqI/vol1NEMR9Z3ncLjIkyIF0o/CQYXzXCDjA91i9+0iMjXGgIgBLn3bfA1b9pHuz4HvwjgYUKMYOkQ==",
-      "requires": {
-        "@libp2p/crypto": "^1.0.11",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-record": "^2.0.1",
-        "@libp2p/logger": "^2.0.5",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/utils": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^7.0.0",
-        "it-all": "^2.0.0",
-        "it-filter": "^2.0.0",
-        "it-foreach": "^1.0.0",
-        "it-map": "^2.0.0",
-        "it-pipe": "^2.0.3",
-        "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
-        "uint8-varint": "^1.0.2",
-        "uint8arraylist": "^2.1.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      }
-    },
-    "@libp2p/peer-store": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.0.tgz",
-      "integrity": "sha512-7GSqRYkJR3E0Vo96XH84X6KNPdwOE1t6jb7jegYzvzKDZMFaceJUZg9om3+ZHCUbethnYuqsY7j0c7OHCB40nA==",
-      "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.3",
-        "@libp2p/interface-peer-store": "^1.2.2",
-        "@libp2p/interface-record": "^2.0.1",
-        "@libp2p/interfaces": "^3.0.3",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/peer-record": "^5.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^7.0.0",
-        "it-all": "^2.0.0",
-        "it-filter": "^2.0.0",
-        "it-foreach": "^1.0.0",
-        "it-map": "^2.0.0",
-        "it-pipe": "^2.0.3",
-        "mortice": "^3.0.0",
-        "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
-        "uint8arraylist": "^2.1.1",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "@libp2p/tcp": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.1.2.tgz",
-      "integrity": "sha512-IKxcAO4qHRgGLT2aqsy2ayUmkra38efJ5mla4lDECjxcUqHnbok+QEPIgDodPbTaEgfbd6ivmwP1YxHLxt9dJA==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-metrics": "^4.0.0",
-        "@libp2p/interface-transport": "^2.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^11.0.3",
-        "@multiformats/multiaddr": "^11.0.0",
-        "stream-to-it": "^0.2.2"
-      }
-    },
-    "@libp2p/tracked-map": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.2.tgz",
-      "integrity": "sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==",
-      "requires": {
-        "@libp2p/interface-metrics": "^4.0.0"
-      }
-    },
-    "@libp2p/utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
-      "integrity": "sha512-EWJNJtlop2ylmGE1BNiMA0u4eTLKoY0LbZ/DOvSDs9VlGSLua9J+LUjp6XV8lazGv7l1rOLiU+1hP5fcmg1+eg==",
-      "requires": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-peer-store": "^1.2.1",
-        "@libp2p/logger": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^3.0.0",
-        "uint8arraylist": "^2.3.2"
-      }
-    },
-    "@libp2p/websockets": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.3.tgz",
-      "integrity": "sha512-/0ie47LEKU5VVeaeE/T6UbvaZbUSmyWXu4KcojY+zl809oONFjagKuZB6T7jJQqAV7WCq7O+ulC2tFOwbID08w==",
-      "requires": {
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.3",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^11.0.3",
-        "@multiformats/multiaddr": "^11.0.0",
-        "@multiformats/multiaddr-to-uri": "^9.0.2",
-        "abortable-iterator": "^4.0.2",
-        "it-ws": "^5.0.6",
-        "p-defer": "^4.0.0",
-        "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1"
-      }
-    },
-    "@multiformats/mafmt": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
-      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
-      "requires": {
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@multiformats/multiaddr": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
-      "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
-      "requires": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      }
-    },
-    "@multiformats/multiaddr-to-uri": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
-      "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
-      "requires": {
-        "@multiformats/multiaddr": "^11.0.0"
-      }
-    },
-    "@multiformats/murmur3": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
-      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
-      "requires": {
-        "multiformats": "^9.5.4",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        }
-      }
-    },
-    "@noble/ed25519": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
-      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
-    },
-    "@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
-    },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "@stablelib/aead": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
-      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
-    },
-    "@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "requires": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "@stablelib/bytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
-      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
-    },
-    "@stablelib/chacha": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
-      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/chacha20poly1305": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
-      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
-      "requires": {
-        "@stablelib/aead": "^1.0.1",
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/chacha": "^1.0.1",
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/poly1305": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
-      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
-    },
-    "@stablelib/hash": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
-    },
-    "@stablelib/hkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
-      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
-      "requires": {
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/hmac": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/hmac": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
-      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
-      "requires": {
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
-    },
-    "@stablelib/keyagreement": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
-      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
-      "requires": {
-        "@stablelib/bytes": "^1.0.1"
-      }
-    },
-    "@stablelib/poly1305": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
-      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
-      "requires": {
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/sha256": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
-      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
-    },
-    "@stablelib/x25519": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
-      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
-      "requires": {
-        "@stablelib/keyagreement": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@types/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w==",
-      "dev": true
-    },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
-    "@types/node": {
-      "version": "18.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.4.tgz",
-      "integrity": "sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow=="
-    },
-    "@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
-    },
-    "@web3-storage/fast-unixfs-exporter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.1.tgz",
-      "integrity": "sha512-ylJN3q6/H2IiDaFLXdDSnSx02dFaa7EqSZGCKN20TlSk0ZvBbQ9BXs1q/arik64KZ/OqtLMwBivehMs+dUO7Gg==",
-      "requires": {
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-pb": "^2.0.2",
-        "@multiformats/murmur3": "^1.0.3",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "interface-blockstore": "^2.0.3",
-        "ipfs-unixfs": "^6.0.0",
-        "it-last": "^1.0.5",
-        "multiformats": "^9.4.2",
-        "p-queue": "^7.3.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "@ipld/dag-cbor": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-          "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
-          "requires": {
-            "cborg": "^1.6.0",
-            "multiformats": "^9.5.4"
-          }
-        },
-        "@ipld/dag-pb": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
-          "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
-          "requires": {
-            "multiformats": "^9.5.4"
-          }
-        },
-        "ipfs-unixfs": {
-          "version": "6.0.9",
-          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
-          "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "protobufjs": "^6.10.2"
-          }
-        },
-        "long": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
-        "protobufjs": {
-          "version": "6.11.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": ">=13.7.0",
-            "long": "^4.0.0"
-          }
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
-    },
-    "@web3-storage/handlebars": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/handlebars/-/handlebars-1.0.0.tgz",
-      "integrity": "sha512-vpFia/UMn0H/f31B/pAtDOe2kzQG+sDCTWsWwL3lpzKbIPU8Px8Yi/vhW3nwfDHbwlAbBDBT0KAfFf/fjWX3tQ==",
-      "requires": {
-        "@handlebars/parser": "^1.1.0",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "yargs": "^16.2.0"
-      }
-    },
-    "abortable-iterator": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-4.0.2.tgz",
-      "integrity": "sha512-SJGELER5yXr9v3kiL6mT5RZ1qlyJ9hV4nm34+vfsdIM1lp3zENQvpsqKgykpFLgRMUn3lzlizLTpiOASW05/+g==",
-      "requires": {
-        "get-iterator": "^2.0.0",
-        "it-stream-types": "^1.0.3"
-      }
-    },
-    "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {
-        "ajv": "^8.0.0"
-      }
-    },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "any-signal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
-    },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
-    },
-    "argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
-        "is-string": "^1.0.7"
-      }
-    },
-    "array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
-    "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "atomically": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
-      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
-      "requires": {
-        "stubborn-fs": "^1.2.4",
-        "when-exit": "^2.0.0"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
-      "requires": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
-    "builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.0.0"
-      }
-    },
-    "busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "requires": {
-        "streamsearch": "^1.1.0"
-      }
-    },
-    "byte-access": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/byte-access/-/byte-access-1.0.1.tgz",
-      "integrity": "sha512-GKYa+lvxnzhgHWj9X+LCsQ4s2/C5uvib573eAOiQKywXMkzFFErY2+yQdzmdE5iWVpmqecsRx3bOtOY4/1eINw==",
-      "requires": {
-        "uint8arraylist": "^2.0.0"
-      }
-    },
-    "bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
-    },
-    "cborg": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
-      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ=="
-    },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "chardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-      "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg=="
-    },
-    "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "conf": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
-      "integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
-      "requires": {
-        "ajv": "^8.12.0",
-        "ajv-formats": "^2.1.1",
-        "atomically": "^2.0.0",
-        "debounce-fn": "^5.1.2",
-        "dot-prop": "^7.2.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.3.8"
-      }
-    },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
-    "dagula": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.2.0.tgz",
-      "integrity": "sha512-X0vzLcAmbpuBH0Xb4Bp47L8idLQFYKuY78mgv2P0WeeZX3pQ2drioku4X0GcxntQUsK/AO/0uXo0kZ+9KBjkrQ==",
-      "requires": {
-        "@chainsafe/libp2p-noise": "^11.0.0",
-        "@ipld/car": "^5.0.3",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.0",
-        "@ipld/dag-pb": "^4.0.0",
-        "@libp2p/interface-connection": "^3.0.8",
-        "@libp2p/interface-peer-id": "^2.0.1",
-        "@libp2p/interface-registrar": "^2.0.8",
-        "@libp2p/interfaces": "^3.3.1",
-        "@libp2p/mplex": "^7.1.1",
-        "@libp2p/tcp": "^6.0.9",
-        "@libp2p/websockets": "^5.0.3",
-        "@multiformats/multiaddr": "^11.3.0",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.1",
-        "archy": "^1.0.0",
-        "conf": "^11.0.1",
-        "debug": "^4.3.4",
-        "it-length-prefixed": "^8.0.4",
-        "it-pipe": "^2.0.3",
-        "libp2p": "^0.42.2",
-        "multiformats": "^11.0.1",
-        "p-defer": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "sade": "^1.8.1",
-        "streaming-iterables": "^7.0.4",
-        "timeout-abort-controller": "^3.0.0"
-      }
-    },
-    "datastore-core": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
-      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
-      "requires": {
-        "@libp2p/logger": "^2.0.0",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^7.0.0",
-        "it-all": "^2.0.0",
-        "it-drain": "^2.0.0",
-        "it-filter": "^2.0.0",
-        "it-map": "^2.0.0",
-        "it-merge": "^2.0.0",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^3.0.0",
-        "it-take": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "debounce-fn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
-      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
-      "requires": {
-        "mimic-fn": "^4.0.0"
-      }
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "default-gateway": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
-      "requires": {
-        "execa": "^5.0.0"
-      }
-    },
-    "define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-      "dev": true,
-      "requires": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      }
-    },
-    "dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "requires": {
-        "path-type": "^4.0.0"
-      }
-    },
-    "dns-over-http-resolver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
-      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
-      "requires": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
-      }
-    },
-    "doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2"
-      }
-    },
-    "dot-prop": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
-      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
-      "requires": {
-        "type-fest": "^2.11.2"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
-      }
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
-    },
-    "err-code": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
-      }
-    },
-    "es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
-    },
-    "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
-    },
-    "eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
-      "dev": true,
-      "requires": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.15.0",
-        "globby": "^11.1.0",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "js-sdsl": "^4.1.4",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.3"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "yocto-queue": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-config-standard": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
-      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-config-standard-jsx": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
-      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-plugin-es": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
-      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-n": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.3.0.tgz",
-      "integrity": "sha512-IyzPnEWHypCWasDpxeJnim60jhlumbmq0pubL6IOcnk8u2y53s5QfT8JnXy7skjHJ44yWHRb11PLtDHuu1kg/Q==",
-      "dev": true,
-      "requires": {
-        "builtins": "^5.0.1",
-        "eslint-plugin-es": "^4.1.0",
-        "eslint-utils": "^3.0.0",
-        "ignore": "^5.1.1",
-        "is-core-module": "^2.10.0",
-        "minimatch": "^3.1.2",
-        "resolve": "^1.22.1",
-        "semver": "^7.3.7"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.1.tgz",
-      "integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-plugin-react": {
-      "version": "7.31.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
-      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
-        "doctrine": "^2.1.0",
-        "estraverse": "^5.3.0",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
-        "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "resolve": {
-          "version": "2.0.0-next.4",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.9.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      }
-    },
-    "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true
-    },
-    "espree": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
-      }
-    },
-    "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.1.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.2.0"
-      }
-    },
-    "estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
-    "event-iterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
-      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
-    },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-    },
-    "execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      }
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
-    },
-    "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      }
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
-    },
-    "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "dev": true,
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
-      "requires": {
-        "flat-cache": "^3.0.4"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
-    "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "dev": true,
-      "requires": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
-      }
-    },
-    "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "dev": true
-    },
-    "freeport-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
-      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg=="
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      }
-    },
-    "functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      }
-    },
-    "get-iterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.0.tgz",
-      "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg=="
-    },
-    "get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-    },
-    "get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
-    "globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.20.2"
-      }
-    },
-    "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "requires": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
-    },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
-    },
-    "hamt-sharding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
-      "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
-      "requires": {
-        "sparse-array": "^1.3.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
-    "hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
-    },
-    "human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
-    },
-    "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true
-    },
-    "import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "interface-blockstore": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
-      "integrity": "sha512-OwVUnlNcx7H5HloK0Myv6c/C1q9cNG11HX6afdeU6q6kbuNj8jKCwVnmJHhC94LZaJ+9hvVOk4IUstb3Esg81w==",
-      "requires": {
-        "interface-store": "^2.0.2",
-        "multiformats": "^9.0.4"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        }
-      }
-    },
-    "interface-datastore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
-      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
-      "requires": {
-        "interface-store": "^3.0.0",
-        "nanoid": "^4.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "interface-store": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
-          "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
-        }
-      }
-    },
-    "interface-store": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
-    },
-    "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      }
-    },
-    "ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-    },
-    "ipaddr.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
-    },
-    "ipfs-unixfs": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
-      "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
-      "dev": true,
-      "requires": {
-        "err-code": "^3.0.1",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3"
-      },
-      "dependencies": {
-        "protons-runtime": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
-          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
-          "dev": true,
-          "requires": {
-            "protobufjs": "^7.0.0",
-            "uint8arraylist": "^2.4.3"
-          }
-        }
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
-    },
-    "is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
-      "requires": {
-        "has-bigints": "^1.0.1"
-      }
-    },
-    "is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true
-    },
-    "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-electron": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
-      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-loopback-addr": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.0.1.tgz",
-      "integrity": "sha512-SEsepLbdWFb13B6U0tt6dYcUM0iK/U7XOC43N70Z4Qb88WpNtp+ospyNI9ddpqncs7Z7brAEsVBTQpaqSNntIw=="
-    },
-    "is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
-    },
-    "is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-    },
-    "is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
-    },
-    "is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-    },
-    "is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
-    "is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "iso-url": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
-      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
-    },
-    "it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg=="
-    },
-    "it-batched-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.0.tgz",
-      "integrity": "sha512-OfztV9UHQmoZ6u5F4y+YOI1Z+5JAhkv3Gexc1a0B7ikcVXc3PFSKlEnHv79u+Yp/h23o3tsF9hHAhuqgHCYT2Q==",
-      "requires": {
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0",
-        "uint8arraylist": "^2.4.1"
-      }
-    },
-    "it-drain": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.0.tgz",
-      "integrity": "sha512-oa/5iyBtRs9UW486vPpyDTC0ee3rqx5qlrPI7txIUJcqqtiO5yVozEB6LQrl5ysQYv+P3y/dlKEqwVqlCV0SEA=="
-    },
-    "it-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
-      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg=="
-    },
-    "it-first": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
-      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA=="
-    },
-    "it-foreach": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.0.tgz",
-      "integrity": "sha512-2j5HK1P6aMwEvgL6K5nzUwOk+81B/mjt05PxiSspFEKwJnqy1LfJYlLLS6llBoM+NdoUxf6EsBCHidFGmsXvhw=="
-    },
-    "it-handshake": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.2.tgz",
-      "integrity": "sha512-Q/EvrB4KWIX5+/wO7edBK3l79Vh28+iWPGZvZSSqwAtOJnHZIvywC+JUbiXPRJVXfICBJRqFETtIJcvrqWL2Zw==",
-      "requires": {
-        "it-pushable": "^3.1.0",
-        "it-reader": "^6.0.1",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0",
-        "uint8arraylist": "^2.0.0"
-      }
-    },
-    "it-last": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
-      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
-    },
-    "it-length-prefixed": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.4.tgz",
-      "integrity": "sha512-5OJ1lxH+IaqJB7lxe8IAIwt9UfSfsmjKJoAI/RO9djYoBDt1Jfy9PeVHUmOfqhqyu/4kJvWBFAJUaG1HhLQ12A==",
-      "requires": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.4",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "it-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
-      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA=="
-    },
-    "it-merge": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
-      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
-      "requires": {
-        "it-pushable": "^3.1.0"
-      }
-    },
-    "it-pair": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.4.tgz",
-      "integrity": "sha512-S3y3mTJ3muuxcHBGcIzNONofAN+G3iAgmSjS78qARkRWI2ImJXybjj0h52uSW+isgrJqIx2iFB/T8ZEBc8kDSw==",
-      "requires": {
-        "it-stream-types": "^1.0.3",
-        "p-defer": "^4.0.0"
-      }
-    },
-    "it-pb-stream": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.4.tgz",
-      "integrity": "sha512-p0chBIT3HrZt3hIqvBEi+NgZxxT25MTJ362nKoHmzA/k/WsUPPbeSz7Ad+wRcGxZn2O5JEXCS5lOGRjSDSnlNg==",
-      "requires": {
-        "it-handshake": "^4.1.2",
-        "it-length-prefixed": "^8.0.2",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.0.0"
-      }
-    },
-    "it-pipe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
-      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
-      "requires": {
-        "it-merge": "^2.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.3"
-      }
-    },
-    "it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
-    },
-    "it-reader": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.2.tgz",
-      "integrity": "sha512-rQdVyml+r/2v8PQsPfJgf626tAkbA7NW1EF6zuucT2Ryy1U6YJtSuCJL8fKuDOyiR/mLzbfP0QQJlSeeoLph2A==",
-      "requires": {
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.0.0"
-      }
-    },
-    "it-sort": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.0.tgz",
-      "integrity": "sha512-yeAE97b5PEjCrWFUiNyR90eJdGslj8FB3cjT84rsc+mzx9lxPyR2zJkYB9ZOJoWE5MMebxqcQCLRT3OSlzo7Zg==",
-      "requires": {
-        "it-all": "^2.0.0"
-      }
-    },
-    "it-stream-types": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
-      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA=="
-    },
-    "it-take": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.0.tgz",
-      "integrity": "sha512-lN3diSTomOvYBk2K0LHAgrQ52DlQfvq8tH/+HLAFpX8Q3JwBkr/BPJEi3Z3Lf8jMmN1KOCBXvt5sXa3eW9vUmg=="
-    },
-    "it-ws": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
-      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
-      "requires": {
-        "event-iterator": "^2.0.0",
-        "iso-url": "^1.1.2",
-        "it-stream-types": "^1.0.2",
-        "uint8arrays": "^4.0.2",
-        "ws": "^8.4.0"
-      }
-    },
-    "js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "requires": {
-        "argparse": "^2.0.1"
-      }
-    },
-    "jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "json-schema-typed": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
-      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
-    },
-    "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
-    "jsx-ast-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
-      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.3"
-      }
-    },
-    "levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      }
-    },
-    "libp2p": {
-      "version": "0.42.2",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.42.2.tgz",
-      "integrity": "sha512-arTOCJEEmAFw5HjlXdULVAFs7Y/dWZmgX/qN4SzuxtSkB0pa+fqn/DIbIfpBi2BuY+QozvnARPF1xJtSdqfqJQ==",
-      "requires": {
-        "@achingbrain/nat-port-mapper": "^1.0.3",
-        "@libp2p/crypto": "^1.0.4",
-        "@libp2p/interface-address-manager": "^2.0.0",
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-connection-encrypter": "^3.0.1",
-        "@libp2p/interface-connection-manager": "^1.1.1",
-        "@libp2p/interface-content-routing": "^2.0.0",
-        "@libp2p/interface-dht": "^2.0.0",
-        "@libp2p/interface-libp2p": "^1.0.0",
-        "@libp2p/interface-metrics": "^4.0.0",
-        "@libp2p/interface-peer-discovery": "^1.0.1",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interface-peer-info": "^1.0.3",
-        "@libp2p/interface-peer-routing": "^1.0.1",
-        "@libp2p/interface-peer-store": "^1.2.2",
-        "@libp2p/interface-pubsub": "^3.0.0",
-        "@libp2p/interface-registrar": "^2.0.3",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interface-transport": "^2.1.0",
-        "@libp2p/interfaces": "^3.0.3",
-        "@libp2p/logger": "^2.0.1",
-        "@libp2p/multistream-select": "^3.0.0",
-        "@libp2p/peer-collections": "^3.0.0",
-        "@libp2p/peer-id": "^2.0.0",
-        "@libp2p/peer-id-factory": "^2.0.0",
-        "@libp2p/peer-record": "^5.0.0",
-        "@libp2p/peer-store": "^6.0.0",
-        "@libp2p/tracked-map": "^3.0.0",
-        "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^11.0.2",
-        "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "any-signal": "^3.0.0",
-        "datastore-core": "^8.0.1",
-        "err-code": "^3.0.1",
-        "events": "^3.3.0",
-        "hashlru": "^2.3.0",
-        "interface-datastore": "^7.0.0",
-        "it-all": "^2.0.0",
-        "it-drain": "^2.0.0",
-        "it-filter": "^2.0.0",
-        "it-first": "^2.0.0",
-        "it-foreach": "^1.0.0",
-        "it-handshake": "^4.1.2",
-        "it-length-prefixed": "^8.0.2",
-        "it-map": "^2.0.0",
-        "it-merge": "^2.0.0",
-        "it-pair": "^2.0.2",
-        "it-pipe": "^2.0.3",
-        "it-sort": "^2.0.0",
-        "it-stream-types": "^1.0.4",
-        "merge-options": "^3.0.4",
-        "multiformats": "^11.0.0",
-        "node-forge": "^1.3.1",
-        "p-fifo": "^1.0.0",
-        "p-retry": "^5.0.0",
-        "p-settle": "^5.0.0",
-        "private-ip": "^3.0.0",
-        "protons-runtime": "^4.0.1",
-        "rate-limiter-flexible": "^2.3.11",
-        "retimer": "^3.0.0",
-        "sanitize-filename": "^1.6.3",
-        "set-delayed-interval": "^1.0.0",
-        "timeout-abort-controller": "^3.0.0",
-        "uint8arraylist": "^2.3.2",
-        "uint8arrays": "^4.0.2",
-        "wherearewe": "^2.0.0",
-        "xsalsa20": "^1.1.0"
-      }
-    },
-    "load-json-file": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^4.0.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0",
-        "type-fest": "^0.3.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-          "dev": true
-        }
-      }
-    },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
-    },
-    "longbits": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/longbits/-/longbits-1.1.0.tgz",
-      "integrity": "sha512-22U2exkkYy7sr7nuQJYx2NEZ2kEMsC69+BxM5h8auLvkVIJa+LwAB5mFIExnuW2dFuYXFOWsFMKXjaWiq/htYQ==",
-      "requires": {
-        "byte-access": "^1.0.1",
-        "uint8arraylist": "^2.0.0"
-      }
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "magic-bytes.js": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.12.tgz",
-      "integrity": "sha512-Rkukya32FnY3dF5nJeAS4Qcry76tXeOe2sXIQGAt969sV04QLormWHXmHn4o/yIbb4wRlnCqWu8fpVg3TU7sFg=="
-    },
-    "merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "requires": {
-        "is-plain-obj": "^2.1.0"
-      }
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
-    },
-    "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true
-    },
-    "mortice": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
-      "integrity": "sha512-eyDUsl1nCR9+JtNksKnaESLP9MgAXCA4w1LTtsmOSQNsThnv++f36rrBu5fC/fdGIwTJZmbiaR/QewptH93pYA==",
-      "requires": {
-        "nanoid": "^4.0.0",
-        "observable-webworkers": "^2.0.1",
-        "p-queue": "^7.2.0",
-        "p-timeout": "^6.0.0"
-      }
-    },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
-    },
-    "mrmime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw=="
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "multiformats": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
-      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
-    },
-    "murmurhash3js-revisited": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
-    },
-    "nanoid": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
-    },
-    "native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "requires": {}
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
-    },
-    "node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
-    },
-    "npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "requires": {
-        "path-key": "^3.0.0"
-      }
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
-    },
-    "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
-        "object-keys": "^1.1.1"
-      }
-    },
-    "object.entries": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
-      }
-    },
-    "object.fromentries": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
-      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
-      }
-    },
-    "object.hasown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
-      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      }
-    },
-    "object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
-      }
-    },
-    "observable-webworkers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
-      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw=="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        }
-      }
-    },
-    "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dev": true,
-      "requires": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
-      }
-    },
-    "p-defer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
-      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
-    },
-    "p-fifo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
-      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-      "requires": {
-        "fast-fifo": "^1.0.0",
-        "p-defer": "^3.0.0"
-      },
-      "dependencies": {
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        }
-      }
-    },
-    "p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "requires": {
-        "yocto-queue": "^1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^2.0.0"
-      },
-      "dependencies": {
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        }
-      }
-    },
-    "p-queue": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-      "requires": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      },
-      "dependencies": {
-        "p-timeout": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
-        }
-      }
-    },
-    "p-reflect": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-3.1.0.tgz",
-      "integrity": "sha512-3sG3UlpisPSaX+o7u2q01hIQmrpkvdl5GSO1ZwL7pfc5kHB2bPF0eFNCfYTrW1/LTUdgmPwBAvmT0Zr8eSmaAQ=="
-    },
-    "p-retry": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
-      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
-      "requires": {
-        "@types/retry": "0.12.1",
-        "retry": "^0.13.1"
-      }
-    },
-    "p-settle": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-5.1.0.tgz",
-      "integrity": "sha512-ujR6UFfh09ziOKyC5aaJak5ZclsjlLw57SYtFZg6yllMofyygnaibQRZ4jf6QPWqoOCGUXyb1cxUKELeAyKO7g==",
-      "requires": {
-        "p-limit": "^4.0.0",
-        "p-reflect": "^3.1.0"
-      }
-    },
-    "p-timeout": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
-      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w=="
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
-    "parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "requires": {
-        "callsites": "^3.0.0"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
-    },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true
-    },
-    "pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
-      }
-    },
-    "platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
-    },
-    "prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "private-ip": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
-      "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
-      "requires": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "ip-regex": "^5.0.0",
-        "ipaddr.js": "^2.0.1",
-        "netmask": "^2.0.2"
-      }
-    },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      }
-    },
-    "protons-runtime": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
-      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
-      "requires": {
-        "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.4.3"
-      }
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
-    },
-    "rate-limiter-flexible": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
-      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
-    "receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
-    },
-    "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
-      }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
-    },
-    "retimer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
-      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
-    },
-    "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
-    },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "requires": {
-        "mri": "^1.1.0"
-      }
-    },
-    "safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
-      }
-    },
-    "sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-      "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "set-delayed-interval": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-delayed-interval/-/set-delayed-interval-1.0.0.tgz",
-      "integrity": "sha512-29fhAwuZlLcuBnW/EwxvLcg2D3ELX+VBDNhnavs3YYkab72qmrcSeQNVdzl8EcPPahGQXhBM6MKdPLCQGMDakw=="
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "sparse-array": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
-      "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
-    },
-    "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-    },
-    "standard": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
-      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
-      "dev": true,
-      "requires": {
-        "eslint": "^8.13.0",
-        "eslint-config-standard": "17.0.0",
-        "eslint-config-standard-jsx": "^11.0.0",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-n": "^15.1.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "eslint-plugin-react": "^7.28.0",
-        "standard-engine": "^15.0.0"
-      }
-    },
-    "standard-engine": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
-      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^8.0.0",
-        "minimist": "^1.2.6",
-        "pkg-conf": "^3.1.0",
-        "xdg-basedir": "^4.0.0"
-      }
-    },
-    "stream-to-it": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-      "requires": {
-        "get-iterator": "^1.0.2"
-      },
-      "dependencies": {
-        "get-iterator": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-          "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
-        }
-      }
-    },
-    "streaming-iterables": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-7.1.0.tgz",
-      "integrity": "sha512-t2KmiLVhqafTRqGefD98s5XAMskfkfprr/BTzPIZz0kWB23iyR7XUkY03yjUf4aZpAuuV2/2SUOVri3LgKuOKw=="
-    },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
-        "side-channel": "^1.0.4"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true
-    },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
-    },
-    "strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
-    },
-    "stubborn-fs": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
-      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "timeout-abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
-      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
-      "requires": {
-        "retimer": "^3.0.0"
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
-      "requires": {
-        "utf8-byte-length": "^1.0.1"
-      }
-    },
-    "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dev": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "^1.2.1"
-      }
-    },
-    "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
-    },
-    "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
-      "peer": true
-    },
-    "uint8-varint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.4.tgz",
-      "integrity": "sha512-FHnaReHRIM7kHe/Ms0I2KGkuSY4o7ouhUJGJeiFEuYWGvBt4Y64+BJ3mV6DqmyYtYTZj4Pz8K/BmViSNFLRrVw==",
-      "requires": {
-        "byte-access": "^1.0.0",
-        "longbits": "^1.1.0",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "uint8arraylist": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
-      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
-      "requires": {
-        "uint8arrays": "^4.0.2"
-      }
-    },
-    "uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "requires": {
-        "multiformats": "^11.0.0"
-      }
-    },
-    "unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      }
-    },
-    "undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "requires": {
-        "busboy": "^1.6.0"
-      }
-    },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "utf8-byte-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-    },
-    "when-exit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
-      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ=="
-    },
-    "wherearewe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
-      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
-      "requires": {
-        "is-electron": "^2.2.0"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
-      "requires": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
-      "requires": {}
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-      "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-    },
-    "xsalsa20": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
-      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
-    },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
-    },
-    "yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,22 @@
       "version": "2.0.2",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@ipld/car": "^4.1.5",
+        "@ipld/car": "^5.1.0",
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^1.5.0",
-        "dagula": "^4.1.0",
+        "dagula": "^4.2.0",
         "magic-bytes.js": "^1.0.12",
         "mrmime": "^1.0.1",
-        "multiformats": "^9.9.0",
+        "multiformats": "^11.0.1",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.1.1"
+        "uint8arrays": "^4.0.3"
       },
       "devDependencies": {
-        "@ipld/dag-cbor": "^7.0.3",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-pb": "^4.0.2",
         "@types/bytes": "^3.1.1",
+        "ipfs-unixfs": "^11.0.0",
         "standard": "^17.0.0",
         "typescript": "^4.8.4"
       }
@@ -58,6 +60,11 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/p-timeout": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
@@ -85,61 +92,39 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-7.0.3.tgz",
-      "integrity": "sha512-kr68a6zEC2y1sp9O1i8MlPu7LgC4U1sLciG/SF9Hvo0kOdDa5a13l3Il9R3rTIqaL9DoVfmQhfpOR/cxY2PWUw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.1.tgz",
+      "integrity": "sha512-pByMPsbuuiAherDV7DRB/sBmxWJcLt2tkuST4vFpv6FZb3/AxKp+ck2f4pHFNaUCaFbGLQa2wN903i8tq8Qr7Q==",
       "dependencies": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection-encrypter": "^1.0.2",
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.2",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-collections": "^2.0.0",
-        "@libp2p/peer-id": "^1.1.8",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@stablelib/hkdf": "^1.0.1",
         "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
         "it-length-prefixed": "^8.0.2",
         "it-pair": "^2.0.2",
-        "it-pb-stream": "^2.0.1",
+        "it-pb-stream": "^2.0.2",
         "it-pipe": "^2.0.3",
         "it-stream-types": "^1.0.4",
-        "protons-runtime": "^2.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protons-runtime": "^4.0.1",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-noise/node_modules/it-length-prefixed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-      "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.4",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -250,88 +235,52 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-4.1.5.tgz",
-      "integrity": "sha512-PFj4XsKOsxu5h12JUoBJ+mrAVqeA8YYq2bZbcE2sAIopJTwJIB5sBVTmc8ylkUsFXEysZQ4xQD+rZb3Ct0lbjQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
+      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
       "dependencies": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
-      }
-    },
-    "node_modules/@ipld/dag-cbor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
-      "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@ipld/dag-json": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
-      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
-      "dependencies": {
-        "cborg": "^1.5.4",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@ipld/dag-pb": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
-      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
-      "dependencies": {
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@libp2p/connection": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/connection/-/connection-2.0.4.tgz",
-      "integrity": "sha512-YGMa0ZTbKdyu4b58mLdVT3XKgfBGp/R5h2FTT/8sB3fHTkJ6Crl3Ad5a+cVuqsWfJhrHDncU3SJaqFH4fxhLmg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/connection/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
+      "dependencies": {
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -339,122 +288,30 @@
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.4.tgz",
-      "integrity": "sha512-3hHZvqi+vI8YoTHE+0u8nA5SYGPLZRLMvbgXQoAn0IyPjez66Taaxym/3p3Duf9QkFlvJu95nzpNzv0OdHs9Yw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.12.tgz",
+      "integrity": "sha512-IvTKqI+7O9sTd7K9JSIRsOj/oruKj66qSopbSWkUd6KkcrYvm5vnreb39XPP+nitZcZFQyXj/ZDqTidAWWfYAg==",
       "dependencies": {
         "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
         "@noble/ed25519": "^1.6.0",
         "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.4.5",
+        "multiformats": "^11.0.0",
         "node-forge": "^1.1.0",
-        "protons-runtime": "^3.1.0",
-        "uint8arrays": "^3.0.0"
+        "protons-runtime": "^4.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/crypto/node_modules/protons-runtime": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-      "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
+    "node_modules/@libp2p/interface-address-manager": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.4.tgz",
+      "integrity": "sha512-RcSi+z+xpVKJXq3BsfLf2rq8zb8VTAFown6uJBu02towMc0enYqqhwlV9DxcCaC573MgQ7gY2s/3XvxQdFraVA==",
       "dependencies": {
-        "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "uint8arraylist": "^2.3.2"
-      }
-    },
-    "node_modules/@libp2p/interface-connection": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.2.tgz",
-      "integrity": "sha512-38R2GQ6BCOtwMi5uWU5MLr+xfEpRmVK9gqOp7jNx+6T7TVn8ji4725XLXNfpzprbOrzZkqf2iER84s8+yX4pMA==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection-encrypter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-1.0.3.tgz",
-      "integrity": "sha512-3HNg52HmanRuV2rbQRMFUVTPceSqoC1+ifK9Jkqw3mbiTXXf1mdsv5uKbqts6QvNY5ABZeQWuqJb2QqibaI0mw==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "it-stream-types": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-keys": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.3.tgz",
-      "integrity": "sha512-K8/HlRl/swbVTWuGHNHF28EytszYfUhKgUHfv8CdbMk9ZA/bgO4uU+d9rcrg/Dhw3511U3aRz2bwl2psn6rJfg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-id": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-1.0.4.tgz",
-      "integrity": "sha512-VRnE0MqmS1kN43hyKCEdkhz0gciuDML7hpL3p8zDm0LnveNMLJsR+/VSUaugCi/muOzLaLk26WffKWbMYfnGfA==",
-      "dependencies": {
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.3.tgz",
-      "integrity": "sha512-QKybxfp/NmDGDMkgf/CTt4fU03ajZnldHr9TYg5wMkJrnVaaHbhDTYBg5YWt+iOH1mgR89/dpKv/Na0ZE5sPIA==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
         "@multiformats/multiaddr": "^11.0.0"
       },
       "engines": {
@@ -462,17 +319,185 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
+    "node_modules/@libp2p/interface-connection": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
+      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
       "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-encrypter": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
+      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-manager": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.7.tgz",
+      "integrity": "sha512-GyRa7FXtwjbch4ucFa/jj6vcaQT2RyhUbH3q0tIOTzjntABTMzQrhn3BWOGU5deRp2K7cVOB/OzrdhHdGUxYQA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-content-routing": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.1.tgz",
+      "integrity": "sha512-M3rYXMhH+102qyZzc0GzkKq10x100nWVXGns2qtN3O82Hy/6FxXdgLUGIGWMdCj/7ilaVAuTwx8V3+DGmDIiMw==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-dht": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.1.tgz",
+      "integrity": "sha512-+yEbt+1hMTR1bITzYyE771jEujimPXqDyFm8T1a8slMpeOD9z5wmLfuCWif8oGZJzXX5YqldWwSwytJQgWXL9g==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keychain": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
+      "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keys": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
+      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.1.1.tgz",
+      "integrity": "sha512-cELZZv/tzFxbUzL3Jvbk+AM2J6kDhIUNBIMMMLuR3LIHfmVJkh31G3ChLUZuKhBwB8wXJ1Ssev3fk1tfz/5DWA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^1.0.0",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
+      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-discovery": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-1.0.5.tgz",
+      "integrity": "sha512-R0TN/vDaCJLvRhop0y4qoPqapHxX4AEQDEtqmpayAA1BuPgbBq4fS4mepR3FAMcNva/szeqVCDuI4gDejtCaVg==",
+      "dependencies": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
+      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-routing": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.7.tgz",
+      "integrity": "sha512-0zxOOmKD6nA3LaArcP9UdRO4vJzEyoRtE34vvQP41UxjcSTaj4em5Fl4Q0RuOMXYPtRp+LdXRYbjJgCSeQoxwA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -480,11 +505,11 @@
       }
     },
     "node_modules/@libp2p/interface-peer-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.2.tgz",
-      "integrity": "sha512-ZjE9AkDtjz4R+SppCgZ66oko7Z9pDsdFk1lbba0hTPA2i0uuWdTYep7bZ3RvKot0Q2UrWg8ySL/30pW+Wp70sA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.8.tgz",
+      "integrity": "sha512-FM9VLmpg9CUBKZ2RW+J7RrQfQVMksLiC8oqENqHgb/VkPJY3kafbn7HIi0NcK6H/H5VcwBIhL15SUJk66O1K6g==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interface-record": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -495,26 +520,16 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-store/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
+    "node_modules/@libp2p/interface-pubsub": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
+      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
       "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "uint8arraylist": "^2.1.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -522,12 +537,39 @@
       }
     },
     "node_modules/@libp2p/interface-record": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.1.tgz",
-      "integrity": "sha512-RqF5jKukI8v3Q8MZb4d8/UVjg0OXbl0R8ErWi/LKf+uklA8kTA7rT4FQXFUBycxrkFmEu/tJnW+R1/4fwRwZVg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.6.tgz",
+      "integrity": "sha512-4EtDkY3sbYapWM8++gVHlv31HZXoLmj9I7CRXUKXzFkVE0GLK/A8jYWl7K0lmf2juPjeYm2eHITeA9/wAtIS3w==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "uint8arraylist": "^2.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-registrar": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.8.tgz",
+      "integrity": "sha512-WbnXB09QF41zZzNgDUAZrRMilqgB7wBMTsSvql8xdDcws+jbaX4wE0iEpRXg1hyd0pz4mooIcMRaH1NiEQ5D8w==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
+      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-stream-types": "^1.0.4"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -535,11 +577,12 @@
       }
     },
     "node_modules/@libp2p/interface-transport": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-1.0.4.tgz",
-      "integrity": "sha512-MOkhtykUrrbgHC1CcAFe/6QTz/BEBbHfu5sf+go6dhBlHXeHI+AcV8Fic5zTZNz71E1SRi2UR+5TVi7ORPL57Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.1.tgz",
+      "integrity": "sha512-xDM/s8iPN/XfNqD9qNelibRMPKkhOLinXwQeNtoTZjarq+Cg6rtO6/5WBG/49hyI3+r+5jd2eykjPGQbb86NFQ==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4"
@@ -549,135 +592,49 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-transport/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-transport/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/interfaces": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-2.0.4.tgz",
-      "integrity": "sha512-MfwkTFyHJtvwNxkjOjzkXyIVvKFtEW2Q3IGRJPyPQMrtB6ll0rGMTlyJ3BQS1bcD0YkNhggFm+8XiU2/0LCBhQ==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-pushable": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "multiformats": "^9.6.3"
-      },
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
+      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-Mtj7ImjRYbaANuT53QRqc7ooBYpWieLo7KbqYYGas5O2AWQeOu/zyGBMM35WbWIo7sMuhCas9XBPJdFOR7A05w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
+      "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
         "interface-datastore": "^7.0.0",
-        "multiformats": "^9.6.3"
+        "multiformats": "^11.0.0"
       },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.0.tgz",
-      "integrity": "sha512-q9OveOhexQ3Fx8h4YbuR4mZtUHwvlOynKnIwTm6x8oBTWfIyAKtlYtrOYdlHfqQztbYpdzRFcapopNJBMx36NQ==",
-      "dependencies": {
-        "interface-store": "^3.0.0",
-        "nanoid": "^3.0.2",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/interface-store": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.0.tgz",
-      "integrity": "sha512-IBJn3hE6hYutwdDcStR76mcwfV98vZc49LkEN9ANHHpsxcm6YbGMJxowO2G3FITU4U5ZH4KJPlHOT6Oe2vzTWA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-1.2.2.tgz",
-      "integrity": "sha512-+DHxpxGpnCAvy/q/G2YJY121NMBS3+065DcQkPfFe+hToqmgO9sSJmZbFeOm/AYpauchvVSUvS75dxGdgQ4R9Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.1.tgz",
+      "integrity": "sha512-0owK1aWgXXtjiohXtjwLV7Ehjdj96eBtsapVt7AzlHA+W8uYnI+x058thq3MisyMDlHiiE3BTh6fEf+t2/0dUw==",
       "dependencies": {
-        "@libp2p/logger": "^1.1.3",
-        "@libp2p/tracked-map": "^1.0.5",
+        "@libp2p/interface-connection": "^3.0.1",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
+        "benchmark": "^2.1.4",
         "err-code": "^3.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^3.0.0",
+        "it-batched-bytes": "^1.0.0",
+        "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/mplex/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/mplex/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
-    "node_modules/@libp2p/mplex/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -685,80 +642,25 @@
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-1.0.6.tgz",
-      "integrity": "sha512-8veeiZDrh7aCvILjNGps4ZLKSKTdBxJZS4SZkuhbCKmq7eX6aJoYoQ5G5MBxEFiBKtgwTKHaSroH3jfvizwDoA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.2.tgz",
+      "integrity": "sha512-NfF0fwQM4sqiLuNGBVc9z2mfz3OigOfyLJ5zekRBGYHkbKWrBRFS3FligUPr9roCOzH6ojjDkKVd5aK9/llfJQ==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
+        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "err-code": "^3.0.1",
-        "it-first": "^1.0.6",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
+        "it-first": "^2.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.3",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
-        "uint8arraylist": "^1.5.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/it-handshake": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-      "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
-      "dependencies": {
-        "it-map": "^1.0.6",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/it-reader": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-      "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-      "dependencies": {
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -766,12 +668,12 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-2.2.0.tgz",
-      "integrity": "sha512-fLHWRms2aiSplZcTfXz6bLGZ62f1jfcW3EkS/TweVRpbWpzbtkW+V1CKkhlF3Qc4pJl7GTA5HAfPWIrVDvBYag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.0.tgz",
+      "integrity": "sha512-rVhfDmkVzfBVR4scAfaKb05htZENx01PYt2USi1EnODyoo2c2U2W5tfOfyaKI/4D+ayQDOjT27G0ZCyAgwkYGw==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.4",
-        "@libp2p/peer-id": "^1.1.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -779,14 +681,14 @@
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-1.1.15.tgz",
-      "integrity": "sha512-Y33JLEfsLmLUjuC2nhQ2lBXP6PIsR892gSsNy4Vd7oILkuRhjPouIojP9BbME0m9bhVbAws+Zh9NBKtp7UH7wA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.2.tgz",
+      "integrity": "sha512-RBjCMtSLnX43OK6zIpMW/cKzEgnsunihgyVPhnB/U7DAAEnovxe8F1Q4jBQp9+9DYSgQJrsdiEBpT5JH0Eh2lA==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.6.3",
-        "uint8arrays": "^3.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -794,143 +696,49 @@
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-1.0.18.tgz",
-      "integrity": "sha512-x7lyPrfF4kkMj6az+h1sq5L6ifTvZt2exKi8yS6/Gi/hT8rfqXROdBDtanMjJivIFlzVKJyZdfW5f5RK9Av3iQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.1.tgz",
+      "integrity": "sha512-CRJmqwNQhDC51sQ9lf6EqEY8HuywwymMVffL2kIYI5ts5k+6gvIXzoSxLf3V3o+OxcroXG4KG0uGxxAi5DUXSA==",
       "dependencies": {
         "@libp2p/crypto": "^1.0.0",
         "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "@libp2p/peer-id": "^1.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^4.0.1",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id-factory/node_modules/protons-runtime": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-      "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
-      "dependencies": {
-        "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-1.0.12.tgz",
-      "integrity": "sha512-1b4aeU4sduRBUH4RKDtYBHKOEXwohrlOoBrrNPKb1WFweLMnG3oznhGusMvKQ8YuXSOTpbNPHrbJ/iJnrBbVUQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.0.tgz",
+      "integrity": "sha512-qGaqYQSRqI/vol1NEMR9Z3ncLjIkyIF0o/CQYXzXCDjA91i9+0iMjXGgIgBLn3bfA1b9pHuz4HvwjgYUKMYOkQ==",
       "dependencies": {
-        "@libp2p/crypto": "^0.22.8",
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/utils": "^1.0.9",
-        "@multiformats/multiaddr": "^10.1.5",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-map": "^2.0.0",
         "it-pipe": "^2.0.3",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^4.0.1",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto": {
-      "version": "0.22.14",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-      "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.1",
-        "@noble/ed25519": "^1.6.0",
-        "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "iso-random-stream": "^2.0.0",
-        "multiformats": "^9.4.5",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/utils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-      "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/logger": "^1.0.1",
-        "@multiformats/multiaddr": "^10.1.1",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "ts-mocha": "^9.0.2",
-        "ts-node": "^10.7.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-      "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-      "dependencies": {
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -938,66 +746,31 @@
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-1.0.17.tgz",
-      "integrity": "sha512-1uvwjJ2dRQyQnms+vBY3CgWpZe+0EYSoCNo7UUE6dhJHIA3q1Syl4kZWukA081m1eFzmMLG2VjsrzUQAfmy+Sw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.0.tgz",
+      "integrity": "sha512-7GSqRYkJR3E0Vo96XH84X6KNPdwOE1t6jb7jegYzvzKDZMFaceJUZg9om3+ZHCUbethnYuqsY7j0c7OHCB40nA==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/peer-record": "^1.0.0",
-        "@multiformats/multiaddr": "^10.1.5",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-map": "^2.0.0",
         "it-pipe": "^2.0.3",
         "mortice": "^3.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-store/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-store/node_modules/protons-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-      "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-      "dependencies": {
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-store/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^4.0.1",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1005,19 +778,18 @@
       }
     },
     "node_modules/@libp2p/tcp": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-3.1.2.tgz",
-      "integrity": "sha512-b2xrzmAx0ktlgzsSgaqeHjtnVNzZeYPZPtgjbGub9zEWHZFuN4XER9XppdCMbvQw/68RHufuSQu8PEDMv5l4VQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.1.2.tgz",
+      "integrity": "sha512-IKxcAO4qHRgGLT2aqsy2ayUmkra38efJ5mla4lDECjxcUqHnbok+QEPIgDodPbTaEgfbd6ivmwP1YxHLxt9dJA==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
-        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.3",
         "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
         "stream-to-it": "^0.2.2"
       },
       "engines": {
@@ -1025,38 +797,12 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/tcp/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/tcp/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/tracked-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-1.0.8.tgz",
-      "integrity": "sha512-tN56iEdSbDuUhDApQV0k93aIQu/vACN8fNHsaWZrFpvwPaXmLb//jn3m34pwnSyaTPjUSendP25+JDzg/2U/mw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.2.tgz",
+      "integrity": "sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==",
       "dependencies": {
-        "@libp2p/interfaces": "^2.0.0"
+        "@libp2p/interface-metrics": "^4.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1064,9 +810,9 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
+      "integrity": "sha512-EWJNJtlop2ylmGE1BNiMA0u4eTLKoY0LbZ/DOvSDs9VlGSLua9J+LUjp6XV8lazGv7l1rOLiU+1hP5fcmg1+eg==",
       "dependencies": {
         "@achingbrain/ip-address": "^8.1.0",
         "@libp2p/interface-connection": "^3.0.2",
@@ -1077,7 +823,7 @@
         "err-code": "^3.0.1",
         "is-loopback-addr": "^2.0.1",
         "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
+        "private-ip": "^3.0.0",
         "uint8arraylist": "^2.3.2"
       },
       "engines": {
@@ -1085,30 +831,13 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/utils/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/websockets": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.4.tgz",
-      "integrity": "sha512-Xu2ENTcc05D+QALo7ayVlMJjKPUoABToUve1JQQmfH2Pb6ck1fACmjLTTpumoRDNm6UZTbkW1k8SgUmzg57iiw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.3.tgz",
+      "integrity": "sha512-/0ie47LEKU5VVeaeE/T6UbvaZbUSmyWXu4KcojY+zl809oONFjagKuZB6T7jJQqAV7WCq7O+ulC2tFOwbID08w==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
+        "@libp2p/interface-transport": "^2.0.0",
         "@libp2p/interfaces": "^3.0.3",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
@@ -1116,37 +845,10 @@
         "@multiformats/multiaddr": "^11.0.0",
         "@multiformats/multiaddr-to-uri": "^9.0.2",
         "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "it-ws": "^5.0.0",
+        "it-ws": "^5.0.6",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
         "wherearewe": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/@libp2p/interfaces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-      "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/websockets/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1165,33 +867,16 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@multiformats/mafmt/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@multiformats/multiaddr": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
-      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
+      "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
       "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
         "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       },
       "engines": {
@@ -1211,23 +896,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-      "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@multiformats/murmur3": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
@@ -1237,10 +905,15 @@
         "murmurhash3js-revisited": "^3.0.0"
       }
     },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
       "funding": [
         {
           "type": "individual",
@@ -1249,9 +922,9 @@
       ]
     },
     "node_modules/@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
       "funding": [
         {
           "type": "individual",
@@ -1474,26 +1147,6 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
-    },
     "node_modules/@types/bytes": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.1.tgz",
@@ -1504,7 +1157,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -1521,16 +1174,10 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "peer": true
-    },
     "node_modules/@web3-storage/fast-unixfs-exporter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.0.tgz",
-      "integrity": "sha512-s0nVjdjSheOSmL2jfe9Nr18lO3UBmyLH2omzYoK7FMuGO+4kBkmMtmuSG/zCAsMSZeUUDe8R37/UnAwB71XqyA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.1.tgz",
+      "integrity": "sha512-ylJN3q6/H2IiDaFLXdDSnSx02dFaa7EqSZGCKN20TlSk0ZvBbQ9BXs1q/arik64KZ/OqtLMwBivehMs+dUO7Gg==",
       "dependencies": {
         "@ipld/dag-cbor": "^7.0.2",
         "@ipld/dag-pb": "^2.0.2",
@@ -1547,6 +1194,79 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/@ipld/dag-cbor": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/@ipld/dag-pb": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/ipfs-unixfs": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^6.10.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@web3-storage/fast-unixfs-exporter/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/@web3-storage/handlebars": {
@@ -1582,6 +1302,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1598,18 +1319,10 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -1635,15 +1348,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -1673,33 +1377,16 @@
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
       "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
-    "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "peer": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-includes": {
       "version": "3.1.5",
@@ -1765,40 +1452,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/atomically": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
-      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
-      "engines": {
-        "node": ">=10.12.0"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
+      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
+      "dependencies": {
+        "stubborn-fs": "^1.2.4",
+        "when-exit": "^2.0.0"
       }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1808,23 +1490,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "peer": true
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builtins": {
       "version": "5.0.1",
@@ -1839,7 +1511,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "peer": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -1889,22 +1560,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cborg": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
-      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -1913,6 +1572,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1928,6 +1588,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1940,33 +1601,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
       "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg=="
     },
-    "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1975,20 +1609,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "dependencies": {
-        "is-regexp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -2010,46 +1630,29 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/conf": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
-      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
+      "integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
       "dependencies": {
-        "ajv": "^8.6.3",
+        "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "atomically": "^1.7.0",
-        "debounce-fn": "^4.0.0",
-        "dot-prop": "^6.0.1",
-        "env-paths": "^2.2.1",
-        "json-schema-typed": "^7.0.3",
-        "onetime": "^5.1.2",
-        "pkg-up": "^3.1.0",
-        "semver": "^7.3.5"
+        "atomically": "^2.0.0",
+        "debounce-fn": "^5.1.2",
+        "dot-prop": "^7.2.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2065,28 +1668,31 @@
       }
     },
     "node_modules/dagula": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.1.0.tgz",
-      "integrity": "sha512-Dkw/33LKo1717rllvwpmP8QqlUzQ+25jfY+dI07MCUGiv6Mqydwo8VsObn2f2msK/1kR1vCOO7KpyXsZYgV59g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.2.0.tgz",
+      "integrity": "sha512-X0vzLcAmbpuBH0Xb4Bp47L8idLQFYKuY78mgv2P0WeeZX3pQ2drioku4X0GcxntQUsK/AO/0uXo0kZ+9KBjkrQ==",
       "dependencies": {
-        "@chainsafe/libp2p-noise": "^7.0.1",
-        "@ipld/car": "^4.1.3",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "@libp2p/interfaces": "^2.0.4",
-        "@libp2p/mplex": "^1.2.1",
-        "@libp2p/tcp": "^3.0.2",
-        "@libp2p/websockets": "^3.0.1",
-        "@multiformats/multiaddr": "^10.3.3",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.0",
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@ipld/car": "^5.0.3",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-connection": "^3.0.8",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/tcp": "^6.0.9",
+        "@libp2p/websockets": "^5.0.3",
+        "@multiformats/multiaddr": "^11.3.0",
+        "@web3-storage/fast-unixfs-exporter": "^0.2.1",
         "archy": "^1.0.0",
-        "conf": "^10.1.2",
+        "conf": "^11.0.1",
         "debug": "^4.3.4",
-        "it-length-prefixed": "^7.0.1",
+        "it-length-prefixed": "^8.0.4",
         "it-pipe": "^2.0.3",
-        "libp2p": "^0.37.3",
-        "multiformats": "^9.7.0",
+        "libp2p": "^0.42.2",
+        "multiformats": "^11.0.1",
         "p-defer": "^4.0.0",
         "protobufjs": "^7.0.0",
         "sade": "^1.8.1",
@@ -2098,49 +1704,37 @@
       }
     },
     "node_modules/datastore-core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-7.0.3.tgz",
-      "integrity": "sha512-DmPsUux63daOfCszxLkcp6LjdJ0k/BQNhIMtoAi5mbraYQnEQkFtKORmTu6XmDX6ujbtaBkeuJAiCBNI7MZklw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
+      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
       "dependencies": {
-        "debug": "^4.1.1",
+        "@libp2p/logger": "^2.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.0.2",
-        "it-drain": "^1.0.4",
-        "it-filter": "^1.0.2",
-        "it-map": "^1.0.5",
-        "it-merge": "^1.0.1",
-        "it-pipe": "^1.1.0",
-        "it-pushable": "^1.4.2",
-        "it-take": "^1.0.1",
-        "uint8arrays": "^3.0.0"
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.3",
+        "it-pushable": "^3.0.0",
+        "it-take": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/datastore-core/node_modules/it-pipe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
-    },
-    "node_modules/datastore-core/node_modules/it-pushable": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
-      "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
-      "dependencies": {
-        "fast-fifo": "^1.0.0"
-      }
-    },
     "node_modules/debounce-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
-      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
+      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
       "dependencies": {
-        "mimic-fn": "^3.0.0"
+        "mimic-fn": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2160,18 +1754,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/deep-is": {
@@ -2207,15 +1789,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2229,13 +1802,14 @@
       }
     },
     "node_modules/dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
+      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
       "dependencies": {
         "debug": "^4.3.1",
         "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -2255,14 +1829,25 @@
       }
     },
     "node_modules/dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "dependencies": {
-        "is-obj": "^2.0.0"
+        "type-fest": "^2.11.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2274,11 +1859,14 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/err-code": {
@@ -2371,6 +1959,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3103,6 +2692,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3114,20 +2704,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "peer": true,
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -3161,38 +2743,14 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "node_modules/function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -3291,6 +2849,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3310,6 +2869,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3321,6 +2881,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3375,15 +2936,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "peer": true,
-      "engines": {
-        "node": ">=4.x"
-      }
-    },
     "node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -3395,6 +2947,19 @@
       "engines": {
         "node": ">=10.0.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/hamt-sharding/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/hamt-sharding/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/has": {
@@ -3422,6 +2987,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3470,15 +3036,6 @@
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "peer": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3525,6 +3082,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3533,7 +3091,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/interface-blockstore": {
       "version": "2.0.3",
@@ -3544,14 +3103,32 @@
         "multiformats": "^9.0.4"
       }
     },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/interface-datastore": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
-      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "dependencies": {
-        "interface-store": "^2.0.2",
-        "nanoid": "^3.0.2",
-        "uint8arrays": "^3.0.0"
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/interface-store": {
@@ -3593,46 +3170,35 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
-      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
+      "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
+      "dev": true,
       "dependencies": {
         "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-unixfs/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "node_modules/ipfs-unixfs/node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "hasInstallScript": true,
+    "node_modules/ipfs-unixfs/node_modules/protons-runtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+      "dev": true,
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/is-arrayish": {
@@ -3651,18 +3217,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "peer": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -3721,14 +3275,15 @@
       }
     },
     "node_modules/is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3745,26 +3300,12 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-loopback-addr": {
@@ -3788,6 +3329,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3805,14 +3347,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3837,17 +3371,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -3903,18 +3426,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -3932,18 +3443,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/iso-random-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
-      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
-      "dependencies": {
-        "events": "^3.3.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/iso-url": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
@@ -3953,29 +3452,63 @@
       }
     },
     "node_modules/it-all": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
+      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-batched-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.0.tgz",
+      "integrity": "sha512-OfztV9UHQmoZ6u5F4y+YOI1Z+5JAhkv3Gexc1a0B7ikcVXc3PFSKlEnHv79u+Yp/h23o3tsF9hHAhuqgHCYT2Q==",
+      "dependencies": {
+        "it-stream-types": "^1.0.4",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-drain": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
-      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.0.tgz",
+      "integrity": "sha512-oa/5iyBtRs9UW486vPpyDTC0ee3rqx5qlrPI7txIUJcqqtiO5yVozEB6LQrl5ysQYv+P3y/dlKEqwVqlCV0SEA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-filter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
-      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
+      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-first": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
+      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-foreach": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-0.1.1.tgz",
-      "integrity": "sha512-ZLxL651N5w5SL/EIIcrXELgYrrkuEKj/TErG93C4lr6lNZziKsf338ljSG85PjQfu7Frg/1wESl5pLrPSFXI9g=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.0.tgz",
+      "integrity": "sha512-2j5HK1P6aMwEvgL6K5nzUwOk+81B/mjt05PxiSspFEKwJnqy1LfJYlLLS6llBoM+NdoUxf6EsBCHidFGmsXvhw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-handshake": {
       "version": "4.1.2",
@@ -3993,37 +3526,21 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/it-handshake/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
     "node_modules/it-last": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
       "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
     },
     "node_modules/it-length-prefixed": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-7.0.1.tgz",
-      "integrity": "sha512-UozKoT0zZPUa0LO9OSq5KaLKPn83U7Vsy/BNAN0TUXfTI/pKrOz6RuyTSOok6NDad12FZsShBGnl9DKlfDT95g==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.4.tgz",
+      "integrity": "sha512-5OJ1lxH+IaqJB7lxe8IAIwt9UfSfsmjKJoAI/RO9djYoBDt1Jfy9PeVHUmOfqhqyu/4kJvWBFAJUaG1HhLQ12A==",
       "dependencies": {
         "err-code": "^3.0.1",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-length-prefixed/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -4031,30 +3548,30 @@
       }
     },
     "node_modules/it-map": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
-      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
-    },
-    "node_modules/it-merge": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-1.0.4.tgz",
-      "integrity": "sha512-DcL6GksTD2HQ7+5/q3JznXaLNfwjyG3/bObaF98da+oHfUiPmdo64oJlT9J8R8G5sJRU7thwaY5zxoAKCn7FJw==",
-      "dependencies": {
-        "it-pushable": "^1.4.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
+      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/it-merge/node_modules/it-pushable": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
-      "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
+    "node_modules/it-merge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
+      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
       "dependencies": {
-        "fast-fifo": "^1.0.0"
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-pair": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.3.tgz",
-      "integrity": "sha512-heCgsbYscFCQY5YvltlGT9tjgLGYo7NxPEoJyl55X4BD2KOXpTyuwOhPLWhi9Io0y6+4ZUXCkyaQXIB6Y8xhRw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.4.tgz",
+      "integrity": "sha512-S3y3mTJ3muuxcHBGcIzNONofAN+G3iAgmSjS78qARkRWI2ImJXybjj0h52uSW+isgrJqIx2iFB/T8ZEBc8kDSw==",
       "dependencies": {
         "it-stream-types": "^1.0.3",
         "p-defer": "^4.0.0"
@@ -4065,9 +3582,9 @@
       }
     },
     "node_modules/it-pb-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.2.tgz",
-      "integrity": "sha512-FR1FM9W71wMTZlAij1Pq4PKNcfVb0TGhUTpNQ3tv0LMV/pJ5cDh4g3jW7jhwB+kHtr7PywD1CybBHaT8iAVpKg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.4.tgz",
+      "integrity": "sha512-p0chBIT3HrZt3hIqvBEi+NgZxxT25MTJ362nKoHmzA/k/WsUPPbeSz7Ad+wRcGxZn2O5JEXCS5lOGRjSDSnlNg==",
       "dependencies": {
         "it-handshake": "^4.1.2",
         "it-length-prefixed": "^8.0.2",
@@ -4079,28 +3596,12 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/it-pb-stream/node_modules/it-length-prefixed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-      "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.4",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
       "dependencies": {
-        "it-merge": "^1.0.4",
+        "it-merge": "^2.0.0",
         "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.3"
       },
@@ -4109,20 +3610,19 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/it-pipe/node_modules/it-pushable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-      "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-    },
     "node_modules/it-pushable": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-2.0.2.tgz",
-      "integrity": "sha512-f/n6HqXGDbHvuMR/3UN+S6W4y/bS1Pxg6Lb0oVc5dbflxy5f3NKkizKs86B8vzqHnB9hm1YpE0pgcEvI3FKDQw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
+      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-reader": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.1.tgz",
-      "integrity": "sha512-C+YRk3OTufbKSJMNEonfEw+9F38llmwwZvqhkjb0xIgob7l4L3p01Yt43+bHRI8SSppAOgk5AKLqas7ea0UTAw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.2.tgz",
+      "integrity": "sha512-rQdVyml+r/2v8PQsPfJgf626tAkbA7NW1EF6zuucT2Ryy1U6YJtSuCJL8fKuDOyiR/mLzbfP0QQJlSeeoLph2A==",
       "dependencies": {
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
@@ -4133,32 +3633,44 @@
       }
     },
     "node_modules/it-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-1.0.1.tgz",
-      "integrity": "sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.0.tgz",
+      "integrity": "sha512-yeAE97b5PEjCrWFUiNyR90eJdGslj8FB3cjT84rsc+mzx9lxPyR2zJkYB9ZOJoWE5MMebxqcQCLRT3OSlzo7Zg==",
       "dependencies": {
-        "it-all": "^1.0.6"
+        "it-all": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-stream-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.4.tgz",
-      "integrity": "sha512-0F3CqTIcIHwtnmIgqd03a7sw8BegAmE32N2w7anIGdALea4oAN4ltqPgDMZ7zn4XPLZifXEZlBXSzgg64L1Ebw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
+      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-take": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
-      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.0.tgz",
+      "integrity": "sha512-lN3diSTomOvYBk2K0LHAgrQ52DlQfvq8tH/+HLAFpX8Q3JwBkr/BPJEi3Z3Lf8jMmN1KOCBXvt5sXa3eW9vUmg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.2.tgz",
-      "integrity": "sha512-beq/nBWuKm2Ds4nYSfPuZRF0USVZJhsIvuUH3kRE5QdaCzivDK7zyeewDgsNBSPr6hPgF5dyPP5NXcXhUcb9QQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
+      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
       "dependencies": {
         "event-iterator": "^2.0.0",
         "iso-url": "^1.1.2",
         "it-stream-types": "^1.0.2",
-        "uint8arrays": "^3.0.0",
+        "uint8arrays": "^4.0.2",
         "ws": "^8.4.0"
       },
       "engines": {
@@ -4182,6 +3694,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4206,9 +3719,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-schema-typed": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4220,7 +3733,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -4255,196 +3768,78 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.37.3.tgz",
-      "integrity": "sha512-G+0tWT6jZr05XE9bG8Kw1SqFrkt1X3bM9TDDXkqWqHvUVjBHWGNDysOvTp7p3jxoSj4J/Z2w9wGbdDsz1kfPlw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.42.2.tgz",
+      "integrity": "sha512-arTOCJEEmAFw5HjlXdULVAFs7Y/dWZmgX/qN4SzuxtSkB0pa+fqn/DIbIfpBi2BuY+QozvnARPF1xJtSdqfqJQ==",
       "dependencies": {
         "@achingbrain/nat-port-mapper": "^1.0.3",
-        "@libp2p/connection": "^2.0.2",
-        "@libp2p/crypto": "^0.22.11",
-        "@libp2p/interfaces": "^2.0.2",
-        "@libp2p/logger": "^1.1.4",
-        "@libp2p/multistream-select": "^1.0.4",
-        "@libp2p/peer-collections": "^1.0.2",
-        "@libp2p/peer-id": "^1.1.10",
-        "@libp2p/peer-id-factory": "^1.0.9",
-        "@libp2p/peer-record": "^1.0.8",
-        "@libp2p/peer-store": "^1.0.10",
-        "@libp2p/tracked-map": "^1.0.5",
-        "@libp2p/utils": "^1.0.10",
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^2.0.0",
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-connection-encrypter": "^3.0.1",
+        "@libp2p/interface-connection-manager": "^1.1.1",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-libp2p": "^1.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^1.0.1",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.0.1",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interface-transport": "^2.1.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/multistream-select": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^6.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.2",
-        "@multiformats/multiaddr": "^10.1.8",
+        "@multiformats/multiaddr": "^11.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
-        "datastore-core": "^7.0.0",
+        "datastore-core": "^8.0.1",
         "err-code": "^3.0.1",
         "events": "^3.3.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-drain": "^1.0.5",
-        "it-filter": "^1.0.3",
-        "it-first": "^1.0.6",
-        "it-foreach": "^0.1.1",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-map": "^1.0.6",
-        "it-merge": "^1.0.3",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-first": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.2",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
         "it-pair": "^2.0.2",
         "it-pipe": "^2.0.3",
-        "it-sort": "^1.0.1",
+        "it-sort": "^2.0.0",
         "it-stream-types": "^1.0.4",
         "merge-options": "^3.0.4",
-        "multiformats": "^9.6.3",
-        "mutable-proxy": "^1.0.0",
-        "node-forge": "^1.2.1",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.3.1",
         "p-fifo": "^1.0.0",
         "p-retry": "^5.0.0",
         "p-settle": "^5.0.0",
-        "private-ip": "^2.3.3",
-        "protons-runtime": "^1.0.4",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^4.0.1",
+        "rate-limiter-flexible": "^2.3.11",
         "retimer": "^3.0.0",
         "sanitize-filename": "^1.6.3",
         "set-delayed-interval": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.0.0",
-        "wherearewe": "^1.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
         "xsalsa20": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/crypto": {
-      "version": "0.22.14",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-      "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.1",
-        "@noble/ed25519": "^1.6.0",
-        "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "iso-random-stream": "^2.0.0",
-        "multiformats": "^9.4.5",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/logger": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-      "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^6.1.0",
-        "multiformats": "^9.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/peer-collections": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-1.0.3.tgz",
-      "integrity": "sha512-xrnFlZ2CpYiUQ0fGE0WqfBONiE2rjkjWHXnS6gH7CudlD0JMSftbzI+naBXRunfZal7CNEtHN7+keVX+ingPgA==",
-      "dependencies": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/peer-id": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/utils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-      "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/logger": "^1.0.1",
-        "@multiformats/multiaddr": "^10.1.1",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "ts-mocha": "^9.0.2",
-        "ts-node": "^10.7.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/it-handshake": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-      "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
-      "dependencies": {
-        "it-map": "^1.0.6",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/it-reader": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-      "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-      "dependencies": {
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/protons-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-      "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-      "dependencies": {
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/uint8arraylist": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-      "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-      "dependencies": {
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/wherearewe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
-      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
-      "dependencies": {
-        "is-electron": "^2.2.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -4480,6 +3875,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -4488,27 +3884,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/long": {
       "version": "5.2.0",
@@ -4556,11 +3941,6 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.12.tgz",
       "integrity": "sha512-Rkukya32FnY3dF5nJeAS4Qcry76tXeOe2sXIQGAt969sV04QLormWHXmHn4o/yIbb4wRlnCqWu8fpVg3TU7sFg=="
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
     "node_modules/merge-options": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
@@ -4600,208 +3980,23 @@
       }
     },
     "node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "node": ">=12"
       },
-      "engines": {
-        "node": ">=10"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
-      "peer": true,
-      "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.3",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.1",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
-    },
-    "node_modules/mocha/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "peer": true
-    },
-    "node_modules/mocha/node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-      "peer": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/mocha/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mortice": {
@@ -4817,17 +4012,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/mortice/node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/mri": {
@@ -4852,9 +4036,13 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -4864,24 +4052,15 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/mutable-proxy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
-      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A==",
-      "engines": {
-        "node": ">=6.X.X",
-        "npm": ">=3.X.X"
-      }
-    },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/native-fetch": {
@@ -4917,15 +4096,6 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -5058,6 +4228,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5147,6 +4318,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -5158,6 +4330,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -5169,9 +4342,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -5206,9 +4379,9 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.1.tgz",
-      "integrity": "sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "dependencies": {
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
@@ -5236,9 +4409,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w==",
       "engines": {
         "node": ">=14.16"
       },
@@ -5250,6 +4423,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5283,6 +4457,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5291,6 +4466,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5322,6 +4498,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5351,16 +4528,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5372,33 +4543,17 @@
       }
     },
     "node_modules/private-ip": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.4.tgz",
-      "integrity": "sha512-ts/YFVwfBeLq61f9+KsOhXW6RH0wvY0gU50R6QZYzgFhggyyLK6WDFeYdjfi/HMnBm2hecLvsR3PB3JcRxDk+A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
+      "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
       "dependencies": {
-        "ip-regex": "^4.3.0",
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.0.1",
-        "is-ip": "^3.1.0",
         "netmask": "^2.0.2"
-      }
-    },
-    "node_modules/private-ip/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/private-ip/node_modules/is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "dependencies": {
-        "ip-regex": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/prop-types": {
@@ -5436,19 +4591,19 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-2.0.2.tgz",
-      "integrity": "sha512-6aBGGn4scICr82Emc6+rS1qhxp9I5YUdfaR4lR10BJ6skyQxbh1vEHkrzGqQrawogwbChDrjLG8H6dI+PLh2tg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
+      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
       "dependencies": {
-        "byte-access": "^1.0.1",
-        "longbits": "^1.1.0",
-        "uint8-varint": "^1.0.2",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/punycode": {
@@ -5479,45 +4634,16 @@
         }
       ]
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
+      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
     },
     "node_modules/receptacle": {
       "version": "1.3.2",
@@ -5670,25 +4796,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -5728,15 +4835,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-delayed-interval": {
@@ -5797,15 +4895,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/sparse-array": {
@@ -5908,17 +4997,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -5996,7 +5076,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -6013,6 +5093,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -6020,36 +5101,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "dependencies": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
+    "node_modules/stubborn-fs": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -6069,20 +5124,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-      "dependencies": {
-        "convert-hrtime": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/timeout-abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
@@ -6095,6 +5136,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -6110,118 +5152,11 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "node_modules/ts-mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
-      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
-      "dependencies": {
-        "ts-node": "7.0.1"
-      },
-      "bin": {
-        "ts-mocha": "bin/ts-mocha"
-      },
-      "engines": {
-        "node": ">= 6.X.X"
-      },
-      "optionalDependencies": {
-        "tsconfig-paths": "^3.5.0"
-      },
-      "peerDependencies": {
-        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-      "dependencies": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-mocha/node_modules/yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -6257,6 +5192,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6278,14 +5214,14 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.3.tgz",
-      "integrity": "sha512-ESs/P/AYPy2wWZCT2V6Tg7RPqA6jzlhJbdsNPFvbDeIrDxj12dwTcm0rD9yFlnmgEf6vRBCZrP3d0SiRTcPwSQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.4.tgz",
+      "integrity": "sha512-FHnaReHRIM7kHe/Ms0I2KGkuSY4o7ouhUJGJeiFEuYWGvBt4Y64+BJ3mV6DqmyYtYTZj4Pz8K/BmViSNFLRrVw==",
       "dependencies": {
         "byte-access": "^1.0.0",
         "longbits": "^1.1.0",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -6293,11 +5229,11 @@
       }
     },
     "node_modules/uint8arraylist": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.3.2.tgz",
-      "integrity": "sha512-4ybc/jixmtGhUrebJ0bzB95TjEbskWxBKBRrAozw7P6WcAcZdPMYSLdDuNoEEGo/Cwe+0TNic9CXzWUWzy1quw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
       "dependencies": {
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -6305,11 +5241,15 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
       "dependencies": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6328,10 +5268,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
-      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
-      "peer": true,
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -6352,11 +5291,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -6365,15 +5299,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
-    },
     "node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
+      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ=="
     },
     "node_modules/wherearewe": {
       "version": "2.0.1",
@@ -6426,12 +5360,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "peer": true
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6451,18 +5379,19 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -6545,29 +5474,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "peer": true,
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
@@ -6605,6 +5511,11 @@
         "xml2js": "^0.4.23"
       },
       "dependencies": {
+        "it-first": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+          "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+        },
         "p-timeout": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
@@ -6624,52 +5535,35 @@
         "xml2js": "^0.4.23"
       }
     },
+    "@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
     "@chainsafe/libp2p-noise": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-7.0.3.tgz",
-      "integrity": "sha512-kr68a6zEC2y1sp9O1i8MlPu7LgC4U1sLciG/SF9Hvo0kOdDa5a13l3Il9R3rTIqaL9DoVfmQhfpOR/cxY2PWUw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.1.tgz",
+      "integrity": "sha512-pByMPsbuuiAherDV7DRB/sBmxWJcLt2tkuST4vFpv6FZb3/AxKp+ck2f4pHFNaUCaFbGLQa2wN903i8tq8Qr7Q==",
       "requires": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection-encrypter": "^1.0.2",
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.2",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/peer-collections": "^2.0.0",
-        "@libp2p/peer-id": "^1.1.8",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@stablelib/hkdf": "^1.0.1",
         "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
         "it-length-prefixed": "^8.0.2",
         "it-pair": "^2.0.2",
-        "it-pb-stream": "^2.0.1",
+        "it-pb-stream": "^2.0.2",
         "it-pipe": "^2.0.3",
         "it-stream-types": "^1.0.4",
-        "protons-runtime": "^2.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "it-length-prefixed": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-          "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "it-stream-types": "^1.0.4",
-            "uint8-varint": "^1.0.1",
-            "uint8arraylist": "^2.0.0",
-            "uint8arrays": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
+        "protons-runtime": "^4.0.1",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
       }
     },
     "@eslint/eslintrc": {
@@ -6758,644 +5652,440 @@
       "dev": true
     },
     "@ipld/car": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-4.1.5.tgz",
-      "integrity": "sha512-PFj4XsKOsxu5h12JUoBJ+mrAVqeA8YYq2bZbcE2sAIopJTwJIB5sBVTmc8ylkUsFXEysZQ4xQD+rZb3Ct0lbjQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.0.tgz",
+      "integrity": "sha512-k9pO0YqJvmFGY5pJDhF2Ocz+mRp3C3r4ikr1NrUXkzN/z4JzhE7XbQzUCcm7daq8k4tRqap0fWPjxZwjS9PUcQ==",
       "requires": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
       }
     },
     "@ipld/dag-cbor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
       "requires": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@ipld/dag-json": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
-      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
       "requires": {
-        "cborg": "^1.5.4",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@ipld/dag-pb": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
-      "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
       "requires": {
-        "multiformats": "^9.5.4"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@libp2p/connection": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/connection/-/connection-2.0.4.tgz",
-      "integrity": "sha512-YGMa0ZTbKdyu4b58mLdVT3XKgfBGp/R5h2FTT/8sB3fHTkJ6Crl3Ad5a+cVuqsWfJhrHDncU3SJaqFH4fxhLmg==",
-      "requires": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1"
-      },
-      "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        }
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/crypto": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.4.tgz",
-      "integrity": "sha512-3hHZvqi+vI8YoTHE+0u8nA5SYGPLZRLMvbgXQoAn0IyPjez66Taaxym/3p3Duf9QkFlvJu95nzpNzv0OdHs9Yw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.12.tgz",
+      "integrity": "sha512-IvTKqI+7O9sTd7K9JSIRsOj/oruKj66qSopbSWkUd6KkcrYvm5vnreb39XPP+nitZcZFQyXj/ZDqTidAWWfYAg==",
       "requires": {
         "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
         "@noble/ed25519": "^1.6.0",
         "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.4.5",
+        "multiformats": "^11.0.0",
         "node-forge": "^1.1.0",
-        "protons-runtime": "^3.1.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "protons-runtime": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-          "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
-          "requires": {
-            "protobufjs": "^7.0.0",
-            "uint8arraylist": "^2.3.2"
-          }
-        }
+        "protons-runtime": "^4.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "@libp2p/interface-address-manager": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.4.tgz",
+      "integrity": "sha512-RcSi+z+xpVKJXq3BsfLf2rq8zb8VTAFown6uJBu02towMc0enYqqhwlV9DxcCaC573MgQ7gY2s/3XvxQdFraVA==",
+      "requires": {
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
       }
     },
     "@libp2p/interface-connection": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.2.tgz",
-      "integrity": "sha512-38R2GQ6BCOtwMi5uWU5MLr+xfEpRmVK9gqOp7jNx+6T7TVn8ji4725XLXNfpzprbOrzZkqf2iER84s8+yX4pMA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
+      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.1"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
+        "uint8arraylist": "^2.1.2"
       }
     },
     "@libp2p/interface-connection-encrypter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-1.0.3.tgz",
-      "integrity": "sha512-3HNg52HmanRuV2rbQRMFUVTPceSqoC1+ifK9Jkqw3mbiTXXf1mdsv5uKbqts6QvNY5ABZeQWuqJb2QqibaI0mw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
+      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "it-stream-types": "^1.0.4"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      }
+    },
+    "@libp2p/interface-connection-manager": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.7.tgz",
+      "integrity": "sha512-GyRa7FXtwjbch4ucFa/jj6vcaQT2RyhUbH3q0tIOTzjntABTMzQrhn3BWOGU5deRp2K7cVOB/OzrdhHdGUxYQA==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-content-routing": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.1.tgz",
+      "integrity": "sha512-M3rYXMhH+102qyZzc0GzkKq10x100nWVXGns2qtN3O82Hy/6FxXdgLUGIGWMdCj/7ilaVAuTwx8V3+DGmDIiMw==",
+      "requires": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-dht": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-dht/-/interface-dht-2.0.1.tgz",
+      "integrity": "sha512-+yEbt+1hMTR1bITzYyE771jEujimPXqDyFm8T1a8slMpeOD9z5wmLfuCWif8oGZJzXX5YqldWwSwytJQgWXL9g==",
+      "requires": {
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-keychain": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
+      "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/interface-keys": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.3.tgz",
-      "integrity": "sha512-K8/HlRl/swbVTWuGHNHF28EytszYfUhKgUHfv8CdbMk9ZA/bgO4uU+d9rcrg/Dhw3511U3aRz2bwl2psn6rJfg=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
+      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA=="
+    },
+    "@libp2p/interface-libp2p": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.1.1.tgz",
+      "integrity": "sha512-cELZZv/tzFxbUzL3Jvbk+AM2J6kDhIUNBIMMMLuR3LIHfmVJkh31G3ChLUZuKhBwB8wXJ1Ssev3fk1tfz/5DWA==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-peer-routing": "^1.0.0",
+        "@libp2p/interface-peer-store": "^1.0.0",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0"
+      }
+    },
+    "@libp2p/interface-metrics": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
+      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0"
+      }
+    },
+    "@libp2p/interface-peer-discovery": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-discovery/-/interface-peer-discovery-1.0.5.tgz",
+      "integrity": "sha512-R0TN/vDaCJLvRhop0y4qoPqapHxX4AEQDEtqmpayAA1BuPgbBq4fS4mepR3FAMcNva/szeqVCDuI4gDejtCaVg==",
+      "requires": {
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
+      }
     },
     "@libp2p/interface-peer-id": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-1.0.4.tgz",
-      "integrity": "sha512-VRnE0MqmS1kN43hyKCEdkhz0gciuDML7hpL3p8zDm0LnveNMLJsR+/VSUaugCi/muOzLaLk26WffKWbMYfnGfA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "requires": {
-        "multiformats": "^9.6.3"
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/interface-peer-info": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.3.tgz",
-      "integrity": "sha512-QKybxfp/NmDGDMkgf/CTt4fU03ajZnldHr9TYg5wMkJrnVaaHbhDTYBg5YWt+iOH1mgR89/dpKv/Na0ZE5sPIA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
+      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
+      }
+    },
+    "@libp2p/interface-peer-routing": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.7.tgz",
+      "integrity": "sha512-0zxOOmKD6nA3LaArcP9UdRO4vJzEyoRtE34vvQP41UxjcSTaj4em5Fl4Q0RuOMXYPtRp+LdXRYbjJgCSeQoxwA==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interfaces": "^3.0.0"
       }
     },
     "@libp2p/interface-peer-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.2.tgz",
-      "integrity": "sha512-ZjE9AkDtjz4R+SppCgZ66oko7Z9pDsdFk1lbba0hTPA2i0uuWdTYep7bZ3RvKot0Q2UrWg8ySL/30pW+Wp70sA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.8.tgz",
+      "integrity": "sha512-FM9VLmpg9CUBKZ2RW+J7RrQfQVMksLiC8oqENqHgb/VkPJY3kafbn7HIi0NcK6H/H5VcwBIhL15SUJk66O1K6g==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interface-record": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
+      }
+    },
+    "@libp2p/interface-pubsub": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
+      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.0.0",
+        "uint8arraylist": "^2.1.2"
       }
     },
     "@libp2p/interface-record": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.1.tgz",
-      "integrity": "sha512-RqF5jKukI8v3Q8MZb4d8/UVjg0OXbl0R8ErWi/LKf+uklA8kTA7rT4FQXFUBycxrkFmEu/tJnW+R1/4fwRwZVg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-2.0.6.tgz",
+      "integrity": "sha512-4EtDkY3sbYapWM8++gVHlv31HZXoLmj9I7CRXUKXzFkVE0GLK/A8jYWl7K0lmf2juPjeYm2eHITeA9/wAtIS3w==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "uint8arraylist": "^2.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "uint8arraylist": "^2.1.2"
       }
     },
-    "@libp2p/interface-transport": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-1.0.4.tgz",
-      "integrity": "sha512-MOkhtykUrrbgHC1CcAFe/6QTz/BEBbHfu5sf+go6dhBlHXeHI+AcV8Fic5zTZNz71E1SRi2UR+5TVi7ORPL57Q==",
+    "@libp2p/interface-registrar": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.8.tgz",
+      "integrity": "sha512-WbnXB09QF41zZzNgDUAZrRMilqgB7wBMTsSvql8xdDcws+jbaX4wE0iEpRXg1hyd0pz4mooIcMRaH1NiEQ5D8w==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0"
+      }
+    },
+    "@libp2p/interface-stream-muxer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
+      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.0",
         "@libp2p/interfaces": "^3.0.0",
+        "it-stream-types": "^1.0.4"
+      }
+    },
+    "@libp2p/interface-transport": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.1.tgz",
+      "integrity": "sha512-xDM/s8iPN/XfNqD9qNelibRMPKkhOLinXwQeNtoTZjarq+Cg6rtO6/5WBG/49hyI3+r+5jd2eykjPGQbb86NFQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
       }
     },
     "@libp2p/interfaces": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-2.0.4.tgz",
-      "integrity": "sha512-MfwkTFyHJtvwNxkjOjzkXyIVvKFtEW2Q3IGRJPyPQMrtB6ll0rGMTlyJ3BQS1bcD0YkNhggFm+8XiU2/0LCBhQ==",
-      "requires": {
-        "@multiformats/multiaddr": "^10.1.5",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-pushable": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "multiformats": "^9.6.3"
-      }
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
+      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
     },
     "@libp2p/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-Mtj7ImjRYbaANuT53QRqc7ooBYpWieLo7KbqYYGas5O2AWQeOu/zyGBMM35WbWIo7sMuhCas9XBPJdFOR7A05w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
+      "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
         "interface-datastore": "^7.0.0",
-        "multiformats": "^9.6.3"
-      },
-      "dependencies": {
-        "interface-datastore": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.0.tgz",
-          "integrity": "sha512-q9OveOhexQ3Fx8h4YbuR4mZtUHwvlOynKnIwTm6x8oBTWfIyAKtlYtrOYdlHfqQztbYpdzRFcapopNJBMx36NQ==",
-          "requires": {
-            "interface-store": "^3.0.0",
-            "nanoid": "^3.0.2",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "interface-store": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.0.tgz",
-          "integrity": "sha512-IBJn3hE6hYutwdDcStR76mcwfV98vZc49LkEN9ANHHpsxcm6YbGMJxowO2G3FITU4U5ZH4KJPlHOT6Oe2vzTWA=="
-        }
+        "multiformats": "^11.0.0"
       }
     },
     "@libp2p/mplex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-1.2.2.tgz",
-      "integrity": "sha512-+DHxpxGpnCAvy/q/G2YJY121NMBS3+065DcQkPfFe+hToqmgO9sSJmZbFeOm/AYpauchvVSUvS75dxGdgQ4R9Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.1.tgz",
+      "integrity": "sha512-0owK1aWgXXtjiohXtjwLV7Ehjdj96eBtsapVt7AzlHA+W8uYnI+x058thq3MisyMDlHiiE3BTh6fEf+t2/0dUw==",
       "requires": {
-        "@libp2p/logger": "^1.1.3",
-        "@libp2p/tracked-map": "^1.0.5",
+        "@libp2p/interface-connection": "^3.0.1",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
+        "benchmark": "^2.1.4",
         "err-code": "^3.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^3.0.0",
+        "it-batched-bytes": "^1.0.0",
+        "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.4.0",
-        "uint8arrays": "^3.0.0",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        }
       }
     },
     "@libp2p/multistream-select": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-1.0.6.tgz",
-      "integrity": "sha512-8veeiZDrh7aCvILjNGps4ZLKSKTdBxJZS4SZkuhbCKmq7eX6aJoYoQ5G5MBxEFiBKtgwTKHaSroH3jfvizwDoA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.2.tgz",
+      "integrity": "sha512-NfF0fwQM4sqiLuNGBVc9z2mfz3OigOfyLJ5zekRBGYHkbKWrBRFS3FligUPr9roCOzH6ojjDkKVd5aK9/llfJQ==",
       "requires": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
+        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
         "err-code": "^3.0.1",
-        "it-first": "^1.0.6",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-pipe": "^2.0.3",
-        "it-pushable": "^2.0.1",
-        "it-reader": "^5.0.0",
+        "it-first": "^2.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.3",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "it-reader": "^6.0.1",
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
-        "uint8arraylist": "^1.5.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "it-handshake": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-          "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
-          "requires": {
-            "it-map": "^1.0.6",
-            "it-pushable": "^2.0.1",
-            "it-reader": "^5.0.0",
-            "it-stream-types": "^1.0.4",
-            "p-defer": "^4.0.0"
-          }
-        },
-        "it-reader": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-          "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-          "requires": {
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^1.2.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        }
+        "uint8arraylist": "^2.3.1",
+        "uint8arrays": "^4.0.2"
       }
     },
     "@libp2p/peer-collections": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-2.2.0.tgz",
-      "integrity": "sha512-fLHWRms2aiSplZcTfXz6bLGZ62f1jfcW3EkS/TweVRpbWpzbtkW+V1CKkhlF3Qc4pJl7GTA5HAfPWIrVDvBYag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.0.tgz",
+      "integrity": "sha512-rVhfDmkVzfBVR4scAfaKb05htZENx01PYt2USi1EnODyoo2c2U2W5tfOfyaKI/4D+ayQDOjT27G0ZCyAgwkYGw==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.4",
-        "@libp2p/peer-id": "^1.1.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0"
       }
     },
     "@libp2p/peer-id": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-1.1.15.tgz",
-      "integrity": "sha512-Y33JLEfsLmLUjuC2nhQ2lBXP6PIsR892gSsNy4Vd7oILkuRhjPouIojP9BbME0m9bhVbAws+Zh9NBKtp7UH7wA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.2.tgz",
+      "integrity": "sha512-RBjCMtSLnX43OK6zIpMW/cKzEgnsunihgyVPhnB/U7DAAEnovxe8F1Q4jBQp9+9DYSgQJrsdiEBpT5JH0Eh2lA==",
       "requires": {
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^9.6.3",
-        "uint8arrays": "^3.0.0"
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
       }
     },
     "@libp2p/peer-id-factory": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-1.0.18.tgz",
-      "integrity": "sha512-x7lyPrfF4kkMj6az+h1sq5L6ifTvZt2exKi8yS6/Gi/hT8rfqXROdBDtanMjJivIFlzVKJyZdfW5f5RK9Av3iQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.1.tgz",
+      "integrity": "sha512-CRJmqwNQhDC51sQ9lf6EqEY8HuywwymMVffL2kIYI5ts5k+6gvIXzoSxLf3V3o+OxcroXG4KG0uGxxAi5DUXSA==",
       "requires": {
         "@libp2p/crypto": "^1.0.0",
         "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-peer-id": "^1.0.0",
-        "@libp2p/peer-id": "^1.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^3.1.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^4.0.1",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "protons-runtime": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-3.1.0.tgz",
-          "integrity": "sha512-S1iSPQC0McdHKJRi0XcATBkWgwWPx46UDfrnshYDXBvGHSYqkFtn4MQ8Gatf67w7FzFtHivA+Hb0ZPq56upG8w==",
-          "requires": {
-            "protobufjs": "^7.0.0",
-            "uint8arraylist": "^2.3.2"
-          }
-        }
+        "uint8arrays": "^4.0.2"
       }
     },
     "@libp2p/peer-record": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-1.0.12.tgz",
-      "integrity": "sha512-1b4aeU4sduRBUH4RKDtYBHKOEXwohrlOoBrrNPKb1WFweLMnG3oznhGusMvKQ8YuXSOTpbNPHrbJ/iJnrBbVUQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.0.tgz",
+      "integrity": "sha512-qGaqYQSRqI/vol1NEMR9Z3ncLjIkyIF0o/CQYXzXCDjA91i9+0iMjXGgIgBLn3bfA1b9pHuz4HvwjgYUKMYOkQ==",
       "requires": {
-        "@libp2p/crypto": "^0.22.8",
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/utils": "^1.0.9",
-        "@multiformats/multiaddr": "^10.1.5",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/utils": "^3.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-map": "^2.0.0",
         "it-pipe": "^2.0.3",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^4.0.1",
+        "uint8-varint": "^1.0.2",
+        "uint8arraylist": "^2.1.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "0.22.14",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-          "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.1",
-            "@noble/ed25519": "^1.6.0",
-            "@noble/secp256k1": "^1.5.4",
-            "err-code": "^3.0.1",
-            "iso-random-stream": "^2.0.0",
-            "multiformats": "^9.4.5",
-            "node-forge": "^1.1.0",
-            "protons-runtime": "^1.0.4",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "@libp2p/utils": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-          "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/logger": "^1.0.1",
-            "@multiformats/multiaddr": "^10.1.1",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "ts-mocha": "^9.0.2",
-            "ts-node": "^10.7.0"
-          }
-        },
-        "protons-runtime": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-          "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-          "requires": {
-            "uint8arraylist": "^1.4.0",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        }
       }
     },
     "@libp2p/peer-store": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-1.0.17.tgz",
-      "integrity": "sha512-1uvwjJ2dRQyQnms+vBY3CgWpZe+0EYSoCNo7UUE6dhJHIA3q1Syl4kZWukA081m1eFzmMLG2VjsrzUQAfmy+Sw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.0.tgz",
+      "integrity": "sha512-7GSqRYkJR3E0Vo96XH84X6KNPdwOE1t6jb7jegYzvzKDZMFaceJUZg9om3+ZHCUbethnYuqsY7j0c7OHCB40nA==",
       "requires": {
-        "@libp2p/interfaces": "^2.0.0",
-        "@libp2p/logger": "^1.1.0",
-        "@libp2p/peer-id": "^1.1.0",
-        "@libp2p/peer-record": "^1.0.0",
-        "@multiformats/multiaddr": "^10.1.5",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-record": "^2.0.1",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-filter": "^1.0.3",
-        "it-foreach": "^0.1.1",
-        "it-map": "^1.0.6",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-map": "^2.0.0",
         "it-pipe": "^2.0.3",
         "mortice": "^3.0.0",
-        "multiformats": "^9.6.3",
-        "protons-runtime": "^1.0.4",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "protons-runtime": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-          "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-          "requires": {
-            "uint8arraylist": "^1.4.0",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        }
+        "multiformats": "^11.0.0",
+        "protons-runtime": "^4.0.1",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2"
       }
     },
     "@libp2p/tcp": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-3.1.2.tgz",
-      "integrity": "sha512-b2xrzmAx0ktlgzsSgaqeHjtnVNzZeYPZPtgjbGub9zEWHZFuN4XER9XppdCMbvQw/68RHufuSQu8PEDMv5l4VQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.1.2.tgz",
+      "integrity": "sha512-IKxcAO4qHRgGLT2aqsy2ayUmkra38efJ5mla4lDECjxcUqHnbok+QEPIgDodPbTaEgfbd6ivmwP1YxHLxt9dJA==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
-        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.3",
         "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
         "stream-to-it": "^0.2.2"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
       }
     },
     "@libp2p/tracked-map": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-1.0.8.tgz",
-      "integrity": "sha512-tN56iEdSbDuUhDApQV0k93aIQu/vACN8fNHsaWZrFpvwPaXmLb//jn3m34pwnSyaTPjUSendP25+JDzg/2U/mw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tracked-map/-/tracked-map-3.0.2.tgz",
+      "integrity": "sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==",
       "requires": {
-        "@libp2p/interfaces": "^2.0.0"
+        "@libp2p/interface-metrics": "^4.0.0"
       }
     },
     "@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
+      "integrity": "sha512-EWJNJtlop2ylmGE1BNiMA0u4eTLKoY0LbZ/DOvSDs9VlGSLua9J+LUjp6XV8lazGv7l1rOLiU+1hP5fcmg1+eg==",
       "requires": {
         "@achingbrain/ip-address": "^8.1.0",
         "@libp2p/interface-connection": "^3.0.2",
@@ -7406,32 +6096,17 @@
         "err-code": "^3.0.1",
         "is-loopback-addr": "^2.0.1",
         "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
+        "private-ip": "^3.0.0",
         "uint8arraylist": "^2.3.2"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
       }
     },
     "@libp2p/websockets": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.4.tgz",
-      "integrity": "sha512-Xu2ENTcc05D+QALo7ayVlMJjKPUoABToUve1JQQmfH2Pb6ck1fACmjLTTpumoRDNm6UZTbkW1k8SgUmzg57iiw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.3.tgz",
+      "integrity": "sha512-/0ie47LEKU5VVeaeE/T6UbvaZbUSmyWXu4KcojY+zl809oONFjagKuZB6T7jJQqAV7WCq7O+ulC2tFOwbID08w==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^1.0.4",
+        "@libp2p/interface-transport": "^2.0.0",
         "@libp2p/interfaces": "^3.0.3",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
@@ -7439,31 +6114,10 @@
         "@multiformats/multiaddr": "^11.0.0",
         "@multiformats/multiaddr-to-uri": "^9.0.2",
         "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "it-ws": "^5.0.0",
+        "it-ws": "^5.0.6",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
         "wherearewe": "^2.0.1"
-      },
-      "dependencies": {
-        "@libp2p/interfaces": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.3.tgz",
-          "integrity": "sha512-8IIxw7TKpaYTtVfZN3jePLlm/E/VzqPpqerN+jhA+1s86akRSeyxVBYi3W9SWDSf0oIauHJSDE8KNxLceAfeag=="
-        },
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
       }
     },
     "@multiformats/mafmt": {
@@ -7472,33 +6126,18 @@
       "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
       "requires": {
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
       }
     },
     "@multiformats/multiaddr": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
-      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
+      "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
       "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
         "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       }
     },
@@ -7508,21 +6147,6 @@
       "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
       "requires": {
         "@multiformats/multiaddr": "^11.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.3.tgz",
-          "integrity": "sha512-B8DOUTNTLczXztLZDjG2vlViVu/2du7dRV5cX7hww5UOwykWypN7xdmxrlwCOp1nFlx2JpCLaCwewdxFrP+8KA==",
-          "requires": {
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "is-ip": "^5.0.0",
-            "multiformats": "^9.4.5",
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        }
       }
     },
     "@multiformats/murmur3": {
@@ -7532,17 +6156,24 @@
       "requires": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
     },
     "@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7750,26 +6381,6 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
-    },
     "@types/bytes": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.1.tgz",
@@ -7780,7 +6391,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "devOptional": true
+      "dev": true
     },
     "@types/long": {
       "version": "4.0.2",
@@ -7797,16 +6408,10 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "peer": true
-    },
     "@web3-storage/fast-unixfs-exporter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.0.tgz",
-      "integrity": "sha512-s0nVjdjSheOSmL2jfe9Nr18lO3UBmyLH2omzYoK7FMuGO+4kBkmMtmuSG/zCAsMSZeUUDe8R37/UnAwB71XqyA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/fast-unixfs-exporter/-/fast-unixfs-exporter-0.2.1.tgz",
+      "integrity": "sha512-ylJN3q6/H2IiDaFLXdDSnSx02dFaa7EqSZGCKN20TlSk0ZvBbQ9BXs1q/arik64KZ/OqtLMwBivehMs+dUO7Gg==",
       "requires": {
         "@ipld/dag-cbor": "^7.0.2",
         "@ipld/dag-pb": "^2.0.2",
@@ -7819,6 +6424,72 @@
         "multiformats": "^9.4.2",
         "p-queue": "^7.3.0",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "@ipld/dag-cbor": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+          "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+          "requires": {
+            "cborg": "^1.6.0",
+            "multiformats": "^9.5.4"
+          }
+        },
+        "@ipld/dag-pb": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
+          "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+          "requires": {
+            "multiformats": "^9.5.4"
+          }
+        },
+        "ipfs-unixfs": {
+          "version": "6.0.9",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
+          "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "protobufjs": "^6.10.2"
+          }
+        },
+        "long": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        },
+        "protobufjs": {
+          "version": "6.11.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "@web3-storage/handlebars": {
@@ -7844,7 +6515,8 @@
     "acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -7853,15 +6525,10 @@
       "dev": true,
       "requires": {}
     },
-    "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
-    },
     "ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7876,12 +6543,6 @@
       "requires": {
         "ajv": "^8.0.0"
       }
-    },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "peer": true
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -7901,30 +6562,16 @@
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
       "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
     },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "peer": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-includes": {
       "version": "3.1.5",
@@ -7969,31 +6616,35 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
-    },
     "atomically": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
-      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
+      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
+      "requires": {
+        "stubborn-fs": "^1.2.4",
+        "when-exit": "^2.0.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "peer": true
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8003,20 +6654,10 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "peer": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "builtins": {
       "version": "5.0.1",
@@ -8031,7 +6672,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "peer": true,
       "requires": {
         "streamsearch": "^1.1.0"
       }
@@ -8065,21 +6705,16 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
-    "camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "peer": true
-    },
     "cborg": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
-      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ=="
     },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -8089,6 +6724,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -8100,22 +6736,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
       "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg=="
     },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "peer": true,
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -8124,14 +6744,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "requires": {
-        "is-regexp": "^3.0.0"
       }
     },
     "color-convert": {
@@ -8150,34 +6762,23 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "conf": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
-      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
+      "integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
       "requires": {
-        "ajv": "^8.6.3",
+        "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "atomically": "^1.7.0",
-        "debounce-fn": "^4.0.0",
-        "dot-prop": "^6.0.1",
-        "env-paths": "^2.2.1",
-        "json-schema-typed": "^7.0.3",
-        "onetime": "^5.1.2",
-        "pkg-up": "^3.1.0",
-        "semver": "^7.3.5"
+        "atomically": "^2.0.0",
+        "debounce-fn": "^5.1.2",
+        "dot-prop": "^7.2.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.3.8"
       }
-    },
-    "convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -8190,28 +6791,31 @@
       }
     },
     "dagula": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.1.0.tgz",
-      "integrity": "sha512-Dkw/33LKo1717rllvwpmP8QqlUzQ+25jfY+dI07MCUGiv6Mqydwo8VsObn2f2msK/1kR1vCOO7KpyXsZYgV59g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-4.2.0.tgz",
+      "integrity": "sha512-X0vzLcAmbpuBH0Xb4Bp47L8idLQFYKuY78mgv2P0WeeZX3pQ2drioku4X0GcxntQUsK/AO/0uXo0kZ+9KBjkrQ==",
       "requires": {
-        "@chainsafe/libp2p-noise": "^7.0.1",
-        "@ipld/car": "^4.1.3",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "@libp2p/interfaces": "^2.0.4",
-        "@libp2p/mplex": "^1.2.1",
-        "@libp2p/tcp": "^3.0.2",
-        "@libp2p/websockets": "^3.0.1",
-        "@multiformats/multiaddr": "^10.3.3",
-        "@web3-storage/fast-unixfs-exporter": "^0.2.0",
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@ipld/car": "^5.0.3",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-connection": "^3.0.8",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interface-registrar": "^2.0.8",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/tcp": "^6.0.9",
+        "@libp2p/websockets": "^5.0.3",
+        "@multiformats/multiaddr": "^11.3.0",
+        "@web3-storage/fast-unixfs-exporter": "^0.2.1",
         "archy": "^1.0.0",
-        "conf": "^10.1.2",
+        "conf": "^11.0.1",
         "debug": "^4.3.4",
-        "it-length-prefixed": "^7.0.1",
+        "it-length-prefixed": "^8.0.4",
         "it-pipe": "^2.0.3",
-        "libp2p": "^0.37.3",
-        "multiformats": "^9.7.0",
+        "libp2p": "^0.42.2",
+        "multiformats": "^11.0.1",
         "p-defer": "^4.0.0",
         "protobufjs": "^7.0.0",
         "sade": "^1.8.1",
@@ -8220,44 +6824,30 @@
       }
     },
     "datastore-core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-7.0.3.tgz",
-      "integrity": "sha512-DmPsUux63daOfCszxLkcp6LjdJ0k/BQNhIMtoAi5mbraYQnEQkFtKORmTu6XmDX6ujbtaBkeuJAiCBNI7MZklw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
+      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
       "requires": {
-        "debug": "^4.1.1",
+        "@libp2p/logger": "^2.0.0",
         "err-code": "^3.0.1",
-        "interface-datastore": "^6.0.2",
-        "it-drain": "^1.0.4",
-        "it-filter": "^1.0.2",
-        "it-map": "^1.0.5",
-        "it-merge": "^1.0.1",
-        "it-pipe": "^1.1.0",
-        "it-pushable": "^1.4.2",
-        "it-take": "^1.0.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "it-pipe": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-          "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
-        },
-        "it-pushable": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
-          "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
-          "requires": {
-            "fast-fifo": "^1.0.0"
-          }
-        }
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
+        "it-pipe": "^2.0.3",
+        "it-pushable": "^3.0.0",
+        "it-take": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       }
     },
     "debounce-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
-      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
+      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
       "requires": {
-        "mimic-fn": "^3.0.0"
+        "mimic-fn": "^4.0.0"
       }
     },
     "debug": {
@@ -8267,12 +6857,6 @@
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "peer": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -8298,12 +6882,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "peer": true
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -8314,13 +6892,14 @@
       }
     },
     "dns-over-http-resolver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz",
-      "integrity": "sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
+      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
       "requires": {
         "debug": "^4.3.1",
         "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2"
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       }
     },
     "doctrine": {
@@ -8333,11 +6912,18 @@
       }
     },
     "dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "requires": {
-        "is-obj": "^2.0.0"
+        "type-fest": "^2.11.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "emoji-regex": {
@@ -8346,9 +6932,9 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
     },
     "err-code": {
       "version": "3.0.1",
@@ -8424,7 +7010,8 @@
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
     },
     "eslint": {
       "version": "8.25.0",
@@ -8952,6 +7539,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -8960,15 +7548,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
-    },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "peer": true
     },
     "flat-cache": {
       "version": "3.0.4",
@@ -8994,25 +7577,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -9078,6 +7650,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9091,6 +7664,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9101,6 +7675,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -9140,12 +7715,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "peer": true
-    },
     "hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -9153,6 +7722,21 @@
       "requires": {
         "sparse-array": "^1.3.1",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
       }
     },
     "has": {
@@ -9173,7 +7757,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -9203,12 +7788,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "peer": true
     },
     "human-signals": {
       "version": "2.1.0",
@@ -9241,6 +7820,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -9249,7 +7829,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "interface-blockstore": {
       "version": "2.0.3",
@@ -9258,16 +7839,30 @@
       "requires": {
         "interface-store": "^2.0.2",
         "multiformats": "^9.0.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "interface-datastore": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
-      "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "requires": {
-        "interface-store": "^2.0.2",
-        "nanoid": "^3.0.2",
-        "uint8arrays": "^3.0.0"
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "interface-store": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+          "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+        }
       }
     },
     "interface-store": {
@@ -9297,37 +7892,24 @@
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
     },
     "ipfs-unixfs": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
-      "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
+      "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
+      "dev": true,
       "requires": {
         "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "dependencies": {
-        "long": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
-        "protobufjs": {
-          "version": "6.11.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+        "protons-runtime": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+          "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+          "dev": true,
           "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": ">=13.7.0",
-            "long": "^4.0.0"
+            "protobufjs": "^7.0.0",
+            "uint8arraylist": "^2.4.3"
           }
         }
       }
@@ -9345,15 +7927,6 @@
       "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
-      }
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "peer": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
       }
     },
     "is-boolean-object": {
@@ -9391,14 +7964,15 @@
       }
     },
     "is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -9409,17 +7983,9 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
-      }
-    },
-    "is-ip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
-      "integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
-      "requires": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
       }
     },
     "is-loopback-addr": {
@@ -9436,7 +8002,8 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -9446,11 +8013,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -9466,11 +8028,6 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -9504,12 +8061,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "peer": true
-    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -9524,44 +8075,45 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "iso-random-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
-      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
-      "requires": {
-        "events": "^3.3.0",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "iso-url": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
       "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
     },
     "it-all": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
+      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg=="
+    },
+    "it-batched-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.0.tgz",
+      "integrity": "sha512-OfztV9UHQmoZ6u5F4y+YOI1Z+5JAhkv3Gexc1a0B7ikcVXc3PFSKlEnHv79u+Yp/h23o3tsF9hHAhuqgHCYT2Q==",
+      "requires": {
+        "it-stream-types": "^1.0.4",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.1"
+      }
     },
     "it-drain": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
-      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.0.tgz",
+      "integrity": "sha512-oa/5iyBtRs9UW486vPpyDTC0ee3rqx5qlrPI7txIUJcqqtiO5yVozEB6LQrl5ysQYv+P3y/dlKEqwVqlCV0SEA=="
     },
     "it-filter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
-      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
+      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg=="
     },
     "it-first": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
+      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA=="
     },
     "it-foreach": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-0.1.1.tgz",
-      "integrity": "sha512-ZLxL651N5w5SL/EIIcrXELgYrrkuEKj/TErG93C4lr6lNZziKsf338ljSG85PjQfu7Frg/1wESl5pLrPSFXI9g=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.0.tgz",
+      "integrity": "sha512-2j5HK1P6aMwEvgL6K5nzUwOk+81B/mjt05PxiSspFEKwJnqy1LfJYlLLS6llBoM+NdoUxf6EsBCHidFGmsXvhw=="
     },
     "it-handshake": {
       "version": "4.1.2",
@@ -9573,13 +8125,6 @@
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
         "uint8arraylist": "^2.0.0"
-      },
-      "dependencies": {
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        }
       }
     },
     "it-last": {
@@ -9588,141 +8133,101 @@
       "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
     },
     "it-length-prefixed": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-7.0.1.tgz",
-      "integrity": "sha512-UozKoT0zZPUa0LO9OSq5KaLKPn83U7Vsy/BNAN0TUXfTI/pKrOz6RuyTSOok6NDad12FZsShBGnl9DKlfDT95g==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.4.tgz",
+      "integrity": "sha512-5OJ1lxH+IaqJB7lxe8IAIwt9UfSfsmjKJoAI/RO9djYoBDt1Jfy9PeVHUmOfqhqyu/4kJvWBFAJUaG1HhLQ12A==",
       "requires": {
         "err-code": "^3.0.1",
         "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^1.2.0",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        }
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       }
     },
     "it-map": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
-      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
+      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA=="
     },
     "it-merge": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-1.0.4.tgz",
-      "integrity": "sha512-DcL6GksTD2HQ7+5/q3JznXaLNfwjyG3/bObaF98da+oHfUiPmdo64oJlT9J8R8G5sJRU7thwaY5zxoAKCn7FJw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
+      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
       "requires": {
-        "it-pushable": "^1.4.0"
-      },
-      "dependencies": {
-        "it-pushable": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
-          "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
-          "requires": {
-            "fast-fifo": "^1.0.0"
-          }
-        }
+        "it-pushable": "^3.1.0"
       }
     },
     "it-pair": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.3.tgz",
-      "integrity": "sha512-heCgsbYscFCQY5YvltlGT9tjgLGYo7NxPEoJyl55X4BD2KOXpTyuwOhPLWhi9Io0y6+4ZUXCkyaQXIB6Y8xhRw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.4.tgz",
+      "integrity": "sha512-S3y3mTJ3muuxcHBGcIzNONofAN+G3iAgmSjS78qARkRWI2ImJXybjj0h52uSW+isgrJqIx2iFB/T8ZEBc8kDSw==",
       "requires": {
         "it-stream-types": "^1.0.3",
         "p-defer": "^4.0.0"
       }
     },
     "it-pb-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.2.tgz",
-      "integrity": "sha512-FR1FM9W71wMTZlAij1Pq4PKNcfVb0TGhUTpNQ3tv0LMV/pJ5cDh4g3jW7jhwB+kHtr7PywD1CybBHaT8iAVpKg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.4.tgz",
+      "integrity": "sha512-p0chBIT3HrZt3hIqvBEi+NgZxxT25MTJ362nKoHmzA/k/WsUPPbeSz7Ad+wRcGxZn2O5JEXCS5lOGRjSDSnlNg==",
       "requires": {
         "it-handshake": "^4.1.2",
         "it-length-prefixed": "^8.0.2",
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
-      },
-      "dependencies": {
-        "it-length-prefixed": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-          "integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "it-stream-types": "^1.0.4",
-            "uint8-varint": "^1.0.1",
-            "uint8arraylist": "^2.0.0",
-            "uint8arrays": "^3.0.0"
-          }
-        }
       }
     },
     "it-pipe": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.4.tgz",
-      "integrity": "sha512-lK0BV0egwfc64DFJva+0Jh1z8UxwmYBpAHDwq21s0OenRCaEDIntx/iOyWH/jg5efBU6Xa8igzmOqm2CPPNDgg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
       "requires": {
-        "it-merge": "^1.0.4",
+        "it-merge": "^2.0.0",
         "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.3"
-      },
-      "dependencies": {
-        "it-pushable": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.0.tgz",
-          "integrity": "sha512-sEAdT86u6aIWvLkH4hlOmgvHpRyUOUG22HD365H+Dh67zYpaPdILmT4Om7Wjdb+m/SjEB81z3nYCoIrgVYpOFA=="
-        }
       }
     },
     "it-pushable": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-2.0.2.tgz",
-      "integrity": "sha512-f/n6HqXGDbHvuMR/3UN+S6W4y/bS1Pxg6Lb0oVc5dbflxy5f3NKkizKs86B8vzqHnB9hm1YpE0pgcEvI3FKDQw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
+      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
     },
     "it-reader": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.1.tgz",
-      "integrity": "sha512-C+YRk3OTufbKSJMNEonfEw+9F38llmwwZvqhkjb0xIgob7l4L3p01Yt43+bHRI8SSppAOgk5AKLqas7ea0UTAw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.2.tgz",
+      "integrity": "sha512-rQdVyml+r/2v8PQsPfJgf626tAkbA7NW1EF6zuucT2Ryy1U6YJtSuCJL8fKuDOyiR/mLzbfP0QQJlSeeoLph2A==",
       "requires": {
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.0.0"
       }
     },
     "it-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-1.0.1.tgz",
-      "integrity": "sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.0.tgz",
+      "integrity": "sha512-yeAE97b5PEjCrWFUiNyR90eJdGslj8FB3cjT84rsc+mzx9lxPyR2zJkYB9ZOJoWE5MMebxqcQCLRT3OSlzo7Zg==",
       "requires": {
-        "it-all": "^1.0.6"
+        "it-all": "^2.0.0"
       }
     },
     "it-stream-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.4.tgz",
-      "integrity": "sha512-0F3CqTIcIHwtnmIgqd03a7sw8BegAmE32N2w7anIGdALea4oAN4ltqPgDMZ7zn4XPLZifXEZlBXSzgg64L1Ebw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
+      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA=="
     },
     "it-take": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
-      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.0.tgz",
+      "integrity": "sha512-lN3diSTomOvYBk2K0LHAgrQ52DlQfvq8tH/+HLAFpX8Q3JwBkr/BPJEi3Z3Lf8jMmN1KOCBXvt5sXa3eW9vUmg=="
     },
     "it-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.2.tgz",
-      "integrity": "sha512-beq/nBWuKm2Ds4nYSfPuZRF0USVZJhsIvuUH3kRE5QdaCzivDK7zyeewDgsNBSPr6hPgF5dyPP5NXcXhUcb9QQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
+      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
       "requires": {
         "event-iterator": "^2.0.0",
         "iso-url": "^1.1.2",
         "it-stream-types": "^1.0.2",
-        "uint8arrays": "^3.0.0",
+        "uint8arrays": "^4.0.2",
         "ws": "^8.4.0"
       }
     },
@@ -9742,6 +8247,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -9763,9 +8269,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-schema-typed": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9777,7 +8283,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -9803,162 +8309,78 @@
       }
     },
     "libp2p": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.37.3.tgz",
-      "integrity": "sha512-G+0tWT6jZr05XE9bG8Kw1SqFrkt1X3bM9TDDXkqWqHvUVjBHWGNDysOvTp7p3jxoSj4J/Z2w9wGbdDsz1kfPlw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.42.2.tgz",
+      "integrity": "sha512-arTOCJEEmAFw5HjlXdULVAFs7Y/dWZmgX/qN4SzuxtSkB0pa+fqn/DIbIfpBi2BuY+QozvnARPF1xJtSdqfqJQ==",
       "requires": {
         "@achingbrain/nat-port-mapper": "^1.0.3",
-        "@libp2p/connection": "^2.0.2",
-        "@libp2p/crypto": "^0.22.11",
-        "@libp2p/interfaces": "^2.0.2",
-        "@libp2p/logger": "^1.1.4",
-        "@libp2p/multistream-select": "^1.0.4",
-        "@libp2p/peer-collections": "^1.0.2",
-        "@libp2p/peer-id": "^1.1.10",
-        "@libp2p/peer-id-factory": "^1.0.9",
-        "@libp2p/peer-record": "^1.0.8",
-        "@libp2p/peer-store": "^1.0.10",
-        "@libp2p/tracked-map": "^1.0.5",
-        "@libp2p/utils": "^1.0.10",
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-address-manager": "^2.0.0",
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-connection-encrypter": "^3.0.1",
+        "@libp2p/interface-connection-manager": "^1.1.1",
+        "@libp2p/interface-content-routing": "^2.0.0",
+        "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-libp2p": "^1.0.0",
+        "@libp2p/interface-metrics": "^4.0.0",
+        "@libp2p/interface-peer-discovery": "^1.0.1",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.3",
+        "@libp2p/interface-peer-routing": "^1.0.1",
+        "@libp2p/interface-peer-store": "^1.2.2",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-registrar": "^2.0.3",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interface-transport": "^2.1.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.1",
+        "@libp2p/multistream-select": "^3.0.0",
+        "@libp2p/peer-collections": "^3.0.0",
+        "@libp2p/peer-id": "^2.0.0",
+        "@libp2p/peer-id-factory": "^2.0.0",
+        "@libp2p/peer-record": "^5.0.0",
+        "@libp2p/peer-store": "^6.0.0",
+        "@libp2p/tracked-map": "^3.0.0",
+        "@libp2p/utils": "^3.0.2",
         "@multiformats/mafmt": "^11.0.2",
-        "@multiformats/multiaddr": "^10.1.8",
+        "@multiformats/multiaddr": "^11.0.0",
         "abortable-iterator": "^4.0.2",
         "any-signal": "^3.0.0",
-        "datastore-core": "^7.0.0",
+        "datastore-core": "^8.0.1",
         "err-code": "^3.0.1",
         "events": "^3.3.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^6.1.0",
-        "it-all": "^1.0.6",
-        "it-drain": "^1.0.5",
-        "it-filter": "^1.0.3",
-        "it-first": "^1.0.6",
-        "it-foreach": "^0.1.1",
-        "it-handshake": "^3.0.1",
-        "it-length-prefixed": "^7.0.1",
-        "it-map": "^1.0.6",
-        "it-merge": "^1.0.3",
+        "interface-datastore": "^7.0.0",
+        "it-all": "^2.0.0",
+        "it-drain": "^2.0.0",
+        "it-filter": "^2.0.0",
+        "it-first": "^2.0.0",
+        "it-foreach": "^1.0.0",
+        "it-handshake": "^4.1.2",
+        "it-length-prefixed": "^8.0.2",
+        "it-map": "^2.0.0",
+        "it-merge": "^2.0.0",
         "it-pair": "^2.0.2",
         "it-pipe": "^2.0.3",
-        "it-sort": "^1.0.1",
+        "it-sort": "^2.0.0",
         "it-stream-types": "^1.0.4",
         "merge-options": "^3.0.4",
-        "multiformats": "^9.6.3",
-        "mutable-proxy": "^1.0.0",
-        "node-forge": "^1.2.1",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.3.1",
         "p-fifo": "^1.0.0",
         "p-retry": "^5.0.0",
         "p-settle": "^5.0.0",
-        "private-ip": "^2.3.3",
-        "protons-runtime": "^1.0.4",
+        "private-ip": "^3.0.0",
+        "protons-runtime": "^4.0.1",
+        "rate-limiter-flexible": "^2.3.11",
         "retimer": "^3.0.0",
         "sanitize-filename": "^1.6.3",
         "set-delayed-interval": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
-        "uint8arrays": "^3.0.0",
-        "wherearewe": "^1.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2",
+        "wherearewe": "^2.0.0",
         "xsalsa20": "^1.1.0"
-      },
-      "dependencies": {
-        "@libp2p/crypto": {
-          "version": "0.22.14",
-          "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-0.22.14.tgz",
-          "integrity": "sha512-5RyGh5ovfqrDD8Io3n5rvVnsTHBf1exIMZ/5eBw7Eoy21xkmzdF1Hy701SoSNmiCuTPXYmxT5WMy2VUDBUG6oQ==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.1",
-            "@noble/ed25519": "^1.6.0",
-            "@noble/secp256k1": "^1.5.4",
-            "err-code": "^3.0.1",
-            "iso-random-stream": "^2.0.0",
-            "multiformats": "^9.4.5",
-            "node-forge": "^1.1.0",
-            "protons-runtime": "^1.0.4",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "@libp2p/logger": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-1.1.6.tgz",
-          "integrity": "sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "debug": "^4.3.3",
-            "interface-datastore": "^6.1.0",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "@libp2p/peer-collections": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-1.0.3.tgz",
-          "integrity": "sha512-xrnFlZ2CpYiUQ0fGE0WqfBONiE2rjkjWHXnS6gH7CudlD0JMSftbzI+naBXRunfZal7CNEtHN7+keVX+ingPgA==",
-          "requires": {
-            "@libp2p/interfaces": "^2.0.0",
-            "@libp2p/peer-id": "^1.1.0"
-          }
-        },
-        "@libp2p/utils": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-1.0.10.tgz",
-          "integrity": "sha512-jlVLfac1IoBlgXL8V+XZYxNw0SOAkKweiLhXWolUbKOgRtMDquJzbwG1n8y9GtdiFKPlkiBwOB7l9xighcOR6w==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/logger": "^1.0.1",
-            "@multiformats/multiaddr": "^10.1.1",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "ts-mocha": "^9.0.2",
-            "ts-node": "^10.7.0"
-          }
-        },
-        "it-handshake": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-3.0.1.tgz",
-          "integrity": "sha512-Rx9ESanlfnC0aMw2LtLJ9YNlCNgnZU7wOHPzPSZTUAjbdZx54kllGR5ndIuoJqF2EtNIsmTiWEncKTgwHNJSSg==",
-          "requires": {
-            "it-map": "^1.0.6",
-            "it-pushable": "^2.0.1",
-            "it-reader": "^5.0.0",
-            "it-stream-types": "^1.0.4",
-            "p-defer": "^4.0.0"
-          }
-        },
-        "it-reader": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-5.0.2.tgz",
-          "integrity": "sha512-OgcWA/ffAALrkuUN2sQsbKa3of5oOyLvlXJgSCZdn9sSLZ0rnNmtsJ3lP/WEfWJH8aUNs3bfG6ja3QXKcCOwFw==",
-          "requires": {
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^1.2.0"
-          }
-        },
-        "protons-runtime": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-          "integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-          "requires": {
-            "uint8arraylist": "^1.4.0",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "uint8arraylist": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-          "integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-          "requires": {
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "wherearewe": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
-          "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
-          "requires": {
-            "is-electron": "^2.2.0"
-          }
-        }
       }
     },
     "load-json-file": {
@@ -9986,26 +8408,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "peer": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      }
     },
     "long": {
       "version": "5.2.0",
@@ -10043,11 +8461,6 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.0.12.tgz",
       "integrity": "sha512-Rkukya32FnY3dF5nJeAS4Qcry76tXeOe2sXIQGAt969sV04QLormWHXmHn4o/yIbb4wRlnCqWu8fpVg3TU7sFg=="
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
     "merge-options": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
@@ -10078,143 +8491,15 @@
       }
     },
     "mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
-    },
-    "minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
-      "peer": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
     },
     "minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
-    },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
-    },
-    "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
-      "peer": true,
-      "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.3",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.1",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "peer": true
-            }
-          }
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "peer": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "peer": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "peer": true
-        },
-        "nanoid": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-          "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-          "peer": true
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "peer": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "peer": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "peer": true
-        },
-        "yocto-queue": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-          "peer": true
-        }
-      }
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
     },
     "mortice": {
       "version": "3.0.1",
@@ -10225,13 +8510,6 @@
         "observable-webworkers": "^2.0.1",
         "p-queue": "^7.2.0",
         "p-timeout": "^6.0.0"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-          "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
-        }
       }
     },
     "mri": {
@@ -10250,24 +8528,19 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
       "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
     },
-    "mutable-proxy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
-      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A=="
-    },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
+      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
     },
     "native-fetch": {
       "version": "4.0.2",
@@ -10295,12 +8568,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "peer": true
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -10392,6 +8659,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -10458,6 +8726,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       },
@@ -10466,6 +8735,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -10473,9 +8743,9 @@
       }
     },
     "p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "requires": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -10494,9 +8764,9 @@
       "integrity": "sha512-3sG3UlpisPSaX+o7u2q01hIQmrpkvdl5GSO1ZwL7pfc5kHB2bPF0eFNCfYTrW1/LTUdgmPwBAvmT0Zr8eSmaAQ=="
     },
     "p-retry": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.1.tgz",
-      "integrity": "sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "requires": {
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
@@ -10512,14 +8782,15 @@
       }
     },
     "p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w=="
     },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -10543,12 +8814,14 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -10570,7 +8843,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -10588,13 +8862,10 @@
         "load-json-file": "^5.2.0"
       }
     },
-    "pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "requires": {
-        "find-up": "^3.0.0"
-      }
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -10603,29 +8874,14 @@
       "dev": true
     },
     "private-ip": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.4.tgz",
-      "integrity": "sha512-ts/YFVwfBeLq61f9+KsOhXW6RH0wvY0gU50R6QZYzgFhggyyLK6WDFeYdjfi/HMnBm2hecLvsR3PB3JcRxDk+A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
+      "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
       "requires": {
-        "ip-regex": "^4.3.0",
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.0.1",
-        "is-ip": "^3.1.0",
         "netmask": "^2.0.2"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
-        },
-        "is-ip": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-          "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-          "requires": {
-            "ip-regex": "^4.0.0"
-          }
-        }
       }
     },
     "prop-types": {
@@ -10659,15 +8915,12 @@
       }
     },
     "protons-runtime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-2.0.2.tgz",
-      "integrity": "sha512-6aBGGn4scICr82Emc6+rS1qhxp9I5YUdfaR4lR10BJ6skyQxbh1vEHkrzGqQrawogwbChDrjLG8H6dI+PLh2tg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
+      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
       "requires": {
-        "byte-access": "^1.0.1",
-        "longbits": "^1.1.0",
-        "uint8-varint": "^1.0.2",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.0.0"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "punycode": {
@@ -10681,39 +8934,16 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "peer": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
+    "rate-limiter-flexible": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
+      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
     },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "peer": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
     },
     "receptacle": {
       "version": "1.3.2",
@@ -10809,11 +9039,6 @@
         "mri": "^1.1.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
     "safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -10844,15 +9069,6 @@
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
-      }
-    },
-    "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "peer": true,
-      "requires": {
-        "randombytes": "^2.1.0"
       }
     },
     "set-delayed-interval": {
@@ -10899,15 +9115,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "sparse-array": {
       "version": "1.3.2",
@@ -10970,16 +9177,7 @@
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "peer": true
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string-width": {
       "version": "4.2.3",
@@ -11041,7 +9239,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "devOptional": true
+      "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -11051,26 +9249,13 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
     },
-    "super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "requires": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      }
-    },
-    "supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "peer": true,
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
+    "stubborn-fs": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -11084,14 +9269,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-      "requires": {
-        "convert-hrtime": "^5.0.0"
-      }
-    },
     "timeout-abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
@@ -11104,6 +9281,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -11116,74 +9294,11 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "ts-mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
-      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
-      "requires": {
-        "ts-node": "7.0.1",
-        "tsconfig-paths": "^3.5.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-        },
-        "ts-node": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-          "requires": {
-            "arrify": "^1.0.0",
-            "buffer-from": "^1.1.0",
-            "diff": "^3.1.0",
-            "make-error": "^1.1.1",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^2.0.0"
-          }
-        },
-        "yn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ=="
-        }
-      }
-    },
-    "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
       "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -11209,7 +9324,8 @@
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.17.3",
@@ -11218,30 +9334,30 @@
       "peer": true
     },
     "uint8-varint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.3.tgz",
-      "integrity": "sha512-ESs/P/AYPy2wWZCT2V6Tg7RPqA6jzlhJbdsNPFvbDeIrDxj12dwTcm0rD9yFlnmgEf6vRBCZrP3d0SiRTcPwSQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.4.tgz",
+      "integrity": "sha512-FHnaReHRIM7kHe/Ms0I2KGkuSY4o7ouhUJGJeiFEuYWGvBt4Y64+BJ3mV6DqmyYtYTZj4Pz8K/BmViSNFLRrVw==",
       "requires": {
         "byte-access": "^1.0.0",
         "longbits": "^1.1.0",
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       }
     },
     "uint8arraylist": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.3.2.tgz",
-      "integrity": "sha512-4ybc/jixmtGhUrebJ0bzB95TjEbskWxBKBRrAozw7P6WcAcZdPMYSLdDuNoEEGo/Cwe+0TNic9CXzWUWzy1quw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
       "requires": {
-        "uint8arrays": "^3.1.0"
+        "uint8arrays": "^4.0.2"
       }
     },
     "uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
       "requires": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^11.0.0"
       }
     },
     "unbox-primitive": {
@@ -11257,10 +9373,9 @@
       }
     },
     "undici": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
-      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
-      "peer": true,
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "requires": {
         "busboy": "^1.6.0"
       }
@@ -11278,25 +9393,20 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
-    "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
-    },
     "varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "when-exit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
+      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ=="
     },
     "wherearewe": {
       "version": "2.0.1",
@@ -11333,12 +9443,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
-    "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "peer": true
-    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -11352,12 +9456,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "requires": {}
     },
     "xdg-basedir": {
@@ -11413,23 +9518,6 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
-    },
-    "yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "peer": true,
-      "requires": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,20 +59,22 @@
   "author": "Alan Shaw",
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
-    "@ipld/car": "^4.1.5",
+    "@ipld/car": "^5.1.0",
     "@web3-storage/handlebars": "^1.0.0",
     "bytes": "^3.1.2",
     "chardet": "^1.5.0",
-    "dagula": "^4.1.0",
+    "dagula": "^4.2.0",
     "magic-bytes.js": "^1.0.12",
     "mrmime": "^1.0.1",
-    "multiformats": "^9.9.0",
+    "multiformats": "^11.0.1",
     "timeout-abort-controller": "^3.0.0",
-    "uint8arrays": "^3.1.1"
+    "uint8arrays": "^4.0.3"
   },
   "devDependencies": {
-    "@ipld/dag-cbor": "^7.0.3",
+    "@ipld/dag-cbor": "^9.0.0",
+    "@ipld/dag-pb": "^4.0.2",
     "@types/bytes": "^3.1.1",
+    "ipfs-unixfs": "^11.0.0",
     "standard": "^17.0.0",
     "typescript": "^4.8.4"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@web3-storage/handlebars": "^1.0.0",
     "bytes": "^3.1.2",
     "chardet": "^1.5.0",
-    "dagula": "^4.2.0",
+    "dagula": "^5.0.0",
     "magic-bytes.js": "^1.0.12",
     "mrmime": "^1.0.1",
     "multiformats": "^11.0.1",

--- a/src/handlers/templates/unixfs-dir-entries.handlebars
+++ b/src/handlers/templates/unixfs-dir-entries.handlebars
@@ -4,7 +4,7 @@
           <div class="{{iconFromExt name}}">&nbsp;</div>
         </td>
         <td>
-          <a href="{{encodeURI path}}">{{name}}</a>
+          <a href="{{encodeIPFSPath path}}">{{name}}</a>
         </td>
         <td class="no-linebreak">
           {{#if hash}}

--- a/src/handlers/templates/unixfs-dir-header.handlebars
+++ b/src/handlers/templates/unixfs-dir-header.handlebars
@@ -42,7 +42,7 @@
         <strong>
           Index of
           {{#each breadcrumbs~}}
-          /{{#if path}}<a href="{{encodeURI path}}">{{name}}</a>{{else}}{{name}}{{/if}}
+          /{{#if path}}<a href="{{encodeIPFSPath path}}">{{name}}</a>{{else}}{{name}}{{/if}}
           {{~else}}
           {{path}}
           {{/each}}
@@ -66,7 +66,7 @@
           <div class="ipfs-_blank">&nbsp;</div>
         </td>
         <td>
-          <a href="{{encodeURI backLink}}">..</a>
+          <a href="{{encodeIPFSPath backLink}}">..</a>
         </td>
         <td></td>
         <td></td>

--- a/src/handlers/unixfs-dir.js
+++ b/src/handlers/unixfs-dir.js
@@ -24,7 +24,7 @@ const registerHelper = (name, fn) => Handlebars.registerHelper(name, fn)
 // @ts-ignore missing handlebars types
 const getTemplate = (name) => Handlebars.templates[name]
 
-registerHelper('encodeURI', encodeURI)
+registerHelper('encodeIPFSPath', (/** @type {string} */ p) => p.split('/').map(s => encodeURIComponent(s)).join('/'))
 registerHelper('encodeURIComponent', encodeURIComponent)
 registerHelper('iconFromExt', name => {
   const ext = name.slice(name.lastIndexOf('.') + 1)
@@ -61,7 +61,7 @@ export async function handleUnixfsDir (request, env, ctx) {
 
   const headers = {
     'Content-Type': 'text/html',
-    Etag: `"DirIndex-dagula@0.0.0_CID-${entry.cid}"`
+    Etag: `"DirIndex-gateway-lib@2.0.2_CID-${entry.cid}"`
   }
 
   if (request.method === 'HEAD') {

--- a/test/handlers/unixfs-dir.spec.js
+++ b/test/handlers/unixfs-dir.spec.js
@@ -2,7 +2,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
 import { Dagula } from 'dagula'
-import { fromString, toString } from 'uint8arrays'
+import { fromString } from 'uint8arrays'
 import { encode } from 'multiformats/block'
 import * as raw from 'multiformats/codecs/raw'
 import * as pb from '@ipld/dag-pb'
@@ -28,7 +28,7 @@ describe('UnixFS handler', () => {
     const env = { DEBUG: 'true' }
     const req = new Request('http://localhost/ipfs/bafy')
     const res = await handleUnixfs(req, env, ctx)
-    const html = toString(new Uint8Array(await res.arrayBuffer()))
+    const html = await res.text()
     assert(html.includes('Puzzle%20People%20%231.png'))
   })
 })

--- a/test/handlers/unixfs-dir.spec.js
+++ b/test/handlers/unixfs-dir.spec.js
@@ -1,0 +1,34 @@
+/* eslint-env browser */
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { Dagula } from 'dagula'
+import { fromString, toString } from 'uint8arrays'
+import { encode } from 'multiformats/block'
+import * as raw from 'multiformats/codecs/raw'
+import * as pb from '@ipld/dag-pb'
+import { sha256 as hasher } from 'multiformats/hashes/sha2'
+import { UnixFS } from 'ipfs-unixfs'
+import { handleUnixfs } from '../../src/handlers/unixfs.js'
+import { mockWaitUntil, mockBlockstore } from '../helpers.js'
+
+describe('UnixFS handler', () => {
+  it('directory correctly links to files whose name includes a #', async () => {
+    const waitUntil = mockWaitUntil()
+    const path = ''
+    const searchParams = new URLSearchParams()
+    const fileBlock = await encode({ value: fromString('test'), codec: raw, hasher })
+    const pbData = pb.createNode(new UnixFS({ type: 'directory' }).marshal(), [{
+      Name: 'Puzzle People #1.png',
+      Hash: fileBlock.cid
+    }])
+    const dirBlock = await encode({ value: pbData, codec: pb, hasher })
+    const blockstore = mockBlockstore([dirBlock, fileBlock])
+    const dagula = new Dagula(blockstore)
+    const ctx = { waitUntil, dagula, dataCid: dirBlock.cid, path, searchParams }
+    const env = { DEBUG: 'true' }
+    const req = new Request('http://localhost/ipfs/bafy')
+    const res = await handleUnixfs(req, env, ctx)
+    const html = toString(new Uint8Array(await res.arrayBuffer()))
+    assert(html.includes('Puzzle%20People%20%231.png'))
+  })
+})


### PR DESCRIPTION
Updates the directory handler to properly URL encode each path component instead of the path as a whole. This is because when inclding it as a whole, characters in filenames that are valiud URL characters (like `#`) are not encoded.

refs https://github.com/nftstorage/nftstorage.link/issues/214