### PR TITLE
chore: use prepare lifecycle hook to run build

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,7 +13,5 @@ runs:
       shell: bash
     - run: npm run lint
       shell: bash
-    - run: npm run build
-      shell: bash
     - run: npm test
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
           package-name: "@web3-storage/gateway-api"
       - uses: actions/checkout@v3
       - uses: ./.github/actions/test
-      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     }
   },
   "scripts": {
+    "prepare": "npm run build",
     "test": "node --test test/**/*.spec.js",
     "lint": "standard",
     "build": "npm run build:types && npm run build:templates",


### PR DESCRIPTION
- npm will prepare the module after an npm install, regardless of how the module is installed (git, pack, etc). this means a dev can run `npm i && npm test` out of the box and it all works nice.
- this is the way.

License: MIT