### PR TITLE
fix: add context cloning middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Typical usage may be something like:
 
 ```js
 import {
+  withContext,
   withCorsHeaders,
   withContentDispositionHeader,
   withErrorHandler,
@@ -32,6 +33,7 @@ import {
 export default {
   fetch (request, env, ctx) {
     const middleware = composeMiddleware(
+      withContext,
       withCorsHeaders,
       withContentDispositionHeader,
       withErrorHandler,

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -6,7 +6,7 @@ import type { TimeoutController } from 'timeout-abort-controller'
 export {}
 
 export interface Environment {
-  DEBUG: string
+  DEBUG?: string
 }
 
 export interface Context {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -9,6 +9,24 @@ import { parseCid, tryParseCid } from './util/cid.js'
 const CF_CACHE_MAX_OBJECT_SIZE = 512 * Math.pow(1024, 2) // 512MB to bytes
 
 /**
+ * Creates a fresh context object that can be mutated by the request.
+ *
+ * The original context object is _shared_ among requests so should be cloned
+ * ASAP using this middleware and the clone should be mutated not the original.
+ *
+ * Some properties in the original context object are not enumerable so need
+ * to be expicitly added.
+ *
+ * @type {import('./bindings').Middleware<Context>}
+ */
+export function withContext (handler) {
+  return (request, env, ctx) => {
+    const context = { ...ctx, waitUntil: ctx.waitUntil.bind(ctx) }
+    return handler(request, env, context)
+  }
+}
+
+/**
  * Adds CORS headers to the response.
  * @type {import('./bindings').Middleware<Context>}
  */

--- a/test/middleware/context.spec.js
+++ b/test/middleware/context.spec.js
@@ -1,0 +1,22 @@
+/* eslint-env browser */
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { mockWaitUntil } from '../helpers.js'
+import { withContext } from '../../src/middleware.js'
+
+describe('withContext', () => {
+  it('should clone the context object', async () => {
+    const waitUntil = mockWaitUntil()
+    const ctx = { waitUntil }
+    const env = { DEBUG: 'true' }
+    const req = new Request('http://localhost/ipfs/bafybeifwq2ywuoziunhtoecesw65p4exisfiskcklujke4fwrpx7y6b2ke')
+
+    const res = await withContext(async (req, env, context) => {
+      assert.notStrictEqual(context, ctx)
+      assert.equal(typeof context.waitUntil, 'function')
+      return new Response()
+    })(req, env, ctx)
+
+    assert.strictEqual(res.status, 200)
+  })
+})


### PR DESCRIPTION
I believe this is the cause of https://github.com/filecoin-project/lassie/issues/340#issuecomment-1613890529

The context object is shared between requests. When https://github.com/web3-storage/gateway-lib/pull/34 landed we started exposing ourselves to this issue.

This PR adds a middleware we can use to create a fresh context object at the start of the middleware stack and fix the problem.