### PR TITLE
feat: cache responses without a content-length header

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -205,7 +205,7 @@ export function withCdnCache (handler) {
         // If no content length (a directory or non-unixfs for example) then
         // try to cache anyway, chances are that total response size will be
         // less than CF_CACHE_MAX_OBJECT_SIZE anyways.
-        ctx.waitUntil(cache.put(request, response.clone()).catch(err => console.warn(err)))
+        ctx.waitUntil(cache.put(request, response.clone()).catch(() => {}))
       }
     }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -203,11 +203,10 @@ export function withCdnCache (handler) {
           ctx.waitUntil(cache.put(request, response.clone()))
         }
       } else {
-        console.log('putting to cache', response)
         // If no content length (a directory or non-unixfs for example) then
         // try to cache anyway, chances are that total response size will be
         // less than CF_CACHE_MAX_OBJECT_SIZE anyways.
-        ctx.waitUntil(cache.put(request, response.clone()))
+        ctx.waitUntil(cache.put(request, response.clone()).catch(err => console.warn(err)))
       }
     }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -193,7 +193,6 @@ export function withCdnCache (handler) {
     }
 
     response = await handler(request, env, ctx)
-    console.log('got response', response)
 
     // cache the repsonse if success status
     if (response.ok) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,4 +1,13 @@
-export const mockWaitUntil = () => () => {}
+/**
+ * @returns {((p: Promise<any>) => void) & { promises: Promise<unknown>[] }}
+ */
+export const mockWaitUntil = () => {
+  const promises = []
+  /** @param {Promise<any>} p */
+  const waitUntil = p => { promises.push(p) }
+  waitUntil.promises = promises
+  return waitUntil
+}
 
 /**
  * @param {import('dagula').Block[]} blocks

--- a/test/middleware/cdn-cache.spec.js
+++ b/test/middleware/cdn-cache.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import { describe, it } from 'node:test'
+import { describe, it, mock } from 'node:test'
 import assert from 'node:assert'
 import { Dagula } from 'dagula'
 import { fromString } from 'uint8arrays'
@@ -30,5 +30,31 @@ describe('withCdnCache', () => {
     const handler = () => { throw new Error('request should not reach handler') }
     const res = await withCdnCache(handler)(req, env, ctx)
     assert.strictEqual(res.status, 412)
+  })
+
+  it('should cache responses without a content-length', async () => {
+    const waitUntil = mockWaitUntil()
+    const path = ''
+    const searchParams = new URLSearchParams()
+    const block = await encode({ value: fromString('test'), codec: raw, hasher })
+    const blockstore = mockBlockstore([block])
+    const dagula = new Dagula(blockstore)
+    const ctx = { waitUntil, dagula, dataCid: block.cid, path, searchParams }
+    const env = { DEBUG: 'true' }
+
+    const req = new Request(`http://localhost/ipfs/${block.cid}`)
+    const caches = { default: { match: () => {}, put: mock.fn((req, res) => Promise.resolve()) } }
+    // set up global default cache to _not_ return a cached response
+    // @ts-ignore mock for tests
+    global.caches = caches
+
+    // handler that returns a response without a content-length header
+    const handler = async () => new Response('no-content-length')
+    const res = await withCdnCache(handler)(req, env, ctx)
+    assert.strictEqual(res.status, 200)
+
+    await Promise.all(waitUntil.promises)
+    assert.equal(caches.default.put.mock.callCount(), 1)
+    assert.equal(caches.default.put.mock.calls[0].arguments[0], req)
   })
 })


### PR DESCRIPTION
Chances are that responses without a content-length header are still cachable. For example: directories and non-unixfs data.

If the content is too big and it throws, then just catch it.