### PR TITLE
fix: CORS headers

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -37,15 +37,12 @@ export function withCorsHeaders (handler) {
     const origin = request.headers.get('origin')
     if (origin) {
       response.headers.set('Access-Control-Allow-Origin', origin)
-      response.headers.set('Vary', 'Origin')
+      response.headers.append('Vary', 'Origin')
     } else {
       response.headers.set('Access-Control-Allow-Origin', '*')
     }
-    response.headers.set('Access-Control-Allow-Methods', 'GET')
-    // response.headers.append('Access-Control-Allow-Headers', 'Range')
-    // response.headers.append('Access-Control-Allow-Headers', 'Content-Range')
-    response.headers.append('Access-Control-Expose-Headers', 'Content-Length')
-    // response.headers.append('Access-Control-Expose-Headers', 'Content-Range')
+    response.headers.set('Access-Control-Allow-Methods', 'GET, HEAD')
+    response.headers.append('Access-Control-Expose-Headers', 'Content-Range')
     return response
   }
 }


### PR DESCRIPTION
* Vary may be set already by handlers, so use append instead
* Added `HEAD` to allowed methods
* Removed `Content-Length` from expose headers as it is superfluous - it is on the [CORS response header safelist](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header)
* Added `Content-Range` to expose headers since we now support range requests